### PR TITLE
마커 mock api 개발 및 openapi 명세 업데이트 (ISSUE-51)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,10 +1,15 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "반짝이 Openapi",
+    "title": "Auth API",
     "version": "1.0.0",
-    "description": "반짝이 앱 REST API docs"
+    "description": "회원가입, 로그인, 이메일 인증 API 명세"
   },
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ],
   "servers": [
     {
       "url": "http://localhost:3000",
@@ -36,14 +41,7 @@
         },
         "responses": {
           "202": {
-            "description": "인증 코드 전송 성공",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
+            "description": "인증 코드 전송 성공"
           }
         }
       },
@@ -75,24 +73,32 @@
         },
         "responses": {
           "202": {
-            "description": "인증 성공",
+            "description": "인증 성공"
+          },
+          "400": {
+            "description": "코드 오류 또는 만료",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
                 }
               }
             }
-          },
-          "400": {
-            "description": "코드 오류 또는 만료"
           }
         }
       }
     },
     "/api/register": {
       "post": {
-        "summary": "회원가입",
+        "summary": "회원가입 (인증된 이메일 필요)",
         "requestBody": {
           "required": true,
           "content": {
@@ -164,7 +170,22 @@
             }
           },
           "400": {
-            "description": "이메일 미인증 또는 중복"
+            "description": "이메일 미인증 또는 중복",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         }
       }
@@ -239,9 +260,388 @@
             }
           },
           "400": {
-            "description": "이메일 또는 비밀번호 오류"
+            "description": "이메일 또는 비밀번호 오류",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            }
           }
         }
+      }
+    },
+    "/api/institutions": {
+      "get": {
+        "summary": "기관 목록 조회",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "Bearer <your-jwt-token>"
+            },
+            "description": "Bearer 토큰"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "기관 목록 반환",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "institutions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "email_domain": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "email_domain"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "institutions"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "요청 오류",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/institutions/bounds": {
+      "get": {
+        "summary": "기관 경계 정보 조회",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "Bearer <your-jwt-token>"
+            },
+            "description": "Bearer 토큰"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "기관 경계 정보 반환",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "bounds": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer"
+                          },
+                          "institution_id": {
+                            "type": "integer"
+                          },
+                          "latitude": {
+                            "type": "number"
+                          },
+                          "longitude": {
+                            "type": "number"
+                          },
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "updated_at": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "institution_id",
+                          "latitude",
+                          "longitude",
+                          "created_at",
+                          "updated_at"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "bounds"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "요청 오류",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/markers": {
+      "get": {
+        "summary": "마커 목록 조회",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "Bearer <your-jwt-token>"
+            },
+            "description": "Bearer 토큰"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "마커 목록 반환",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "markers": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer"
+                          },
+                          "post_id": {
+                            "type": "integer"
+                          },
+                          "latitude": {
+                            "type": "number"
+                          },
+                          "longitude": {
+                            "type": "number"
+                          },
+                          "expires_at": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "post_id",
+                          "latitude",
+                          "longitude",
+                          "expires_at"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "markers"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "요청 오류",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "인증 실패 (토큰 누락 또는 유효하지 않음)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/members/me": {
+      "get": {
+        "summary": "내 정보 조회",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "Bearer <your-jwt-token>"
+            },
+            "description": "Bearer 토큰"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "회원 정보 반환",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "member": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        },
+                        "email": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "joined_at": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "email",
+                        "name",
+                        "joined_at"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "member"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "인증 실패 (토큰 누락 또는 유효하지 않음)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
       }
     }
   }

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -3,6 +3,8 @@ info:
   title: Auth API
   version: 1.0.0
   description: 회원가입, 로그인, 이메일 인증 API 명세
+security:
+  - bearerAuth: []
 servers:
   - url: http://localhost:3000
     description: 로컬 개발 서버
@@ -25,10 +27,6 @@ paths:
       responses:
         "202":
           description: 인증 코드 전송 성공
-          content:
-            application/json:
-              schema:
-                type: object
     put:
       summary: 이메일 인증 코드 확인
       requestBody:
@@ -50,15 +48,20 @@ paths:
       responses:
         "202":
           description: 인증 성공
+        "400":
+          description: 코드 오류 또는 만료
           content:
             application/json:
               schema:
                 type: object
-        "400":
-          description: 코드 오류 또는 만료
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
   /api/register:
     post:
-      summary: 회원가입
+      summary: 회원가입 (인증된 이메일 필요)
       requestBody:
         required: true
         content:
@@ -108,6 +111,15 @@ paths:
                   - token
         "400":
           description: 이메일 미인증 또는 중복
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
   /api/login:
     post:
       summary: 로그인
@@ -157,3 +169,224 @@ paths:
                   - token
         "400":
           description: 이메일 또는 비밀번호 오류
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /api/institutions:
+    get:
+      summary: 기관 목록 조회
+      security:
+        - bearerAuth: []
+      parameters:
+        - &a1
+          name: Authorization
+          in: header
+          required: true
+          schema:
+            type: string
+            example: Bearer <your-jwt-token>
+          description: Bearer 토큰
+      responses:
+        "200":
+          description: 기관 목록 반환
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  institutions:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                        name:
+                          type: string
+                        email_domain:
+                          type: string
+                      required:
+                        - id
+                        - name
+                        - email_domain
+                required:
+                  - institutions
+        "400":
+          description: 요청 오류
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /api/institutions/bounds:
+    get:
+      summary: 기관 경계 정보 조회
+      security:
+        - bearerAuth: []
+      parameters:
+        - *a1
+      responses:
+        "200":
+          description: 기관 경계 정보 반환
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  bounds:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                        institution_id:
+                          type: integer
+                        latitude:
+                          type: number
+                        longitude:
+                          type: number
+                        created_at:
+                          type: string
+                        updated_at:
+                          type: string
+                      required:
+                        - id
+                        - institution_id
+                        - latitude
+                        - longitude
+                        - created_at
+                        - updated_at
+                required:
+                  - bounds
+        "400":
+          description: 요청 오류
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /api/markers:
+    get:
+      summary: 마커 목록 조회
+      security:
+        - bearerAuth: []
+      parameters:
+        - *a1
+      responses:
+        "200":
+          description: 마커 목록 반환
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  markers:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                        post_id:
+                          type: integer
+                        latitude:
+                          type: number
+                        longitude:
+                          type: number
+                        expires_at:
+                          type: string
+                      required:
+                        - id
+                        - post_id
+                        - latitude
+                        - longitude
+                        - expires_at
+                required:
+                  - markers
+        "400":
+          description: 요청 오류
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        "401":
+          description: 인증 실패 (토큰 누락 또는 유효하지 않음)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /api/members/me:
+    get:
+      summary: 내 정보 조회
+      security:
+        - bearerAuth: []
+      parameters:
+        - *a1
+      responses:
+        "200":
+          description: 회원 정보 반환
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  member:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                      email:
+                        type: string
+                      name:
+                        type: string
+                      joined_at:
+                        type: string
+                    required:
+                      - id
+                      - email
+                      - name
+                      - joined_at
+                required:
+                  - member
+        "401":
+          description: 인증 실패 (토큰 누락 또는 유효하지 않음)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/openapi/auth/index.ts
+++ b/openapi/auth/index.ts
@@ -8,6 +8,7 @@ import {
   RegisterRequestBodySchema,
   RegisterResponseBodySchema,
 } from '../../src/domains/auth/schema';
+import { ErrorSchema } from '../../src/domains/error/schema';
 
 export const authApiPaths = {
   [`${currentApiPrefix}/verify-email`]: {
@@ -53,6 +54,11 @@ export const authApiPaths = {
         },
         400: {
           description: '코드 오류 또는 만료',
+          content: {
+            'application/json': {
+              schema: ErrorSchema,
+            }
+          }
         },
       },
     },
@@ -80,6 +86,11 @@ export const authApiPaths = {
         },
         400: {
           description: '이메일 미인증 또는 중복',
+          content: {
+            'application/json': {
+              schema: ErrorSchema,
+            }
+          }
         },
       },
     },
@@ -107,6 +118,11 @@ export const authApiPaths = {
         },
         400: {
           description: '이메일 또는 비밀번호 오류',
+          content: {
+            'application/json': {
+              schema: ErrorSchema,
+            }
+          }
         },
       },
     },

--- a/openapi/auth/index.ts
+++ b/openapi/auth/index.ts
@@ -2,7 +2,6 @@ import { currentApiPrefix } from '../../src/constants';
 import {
   EmailCodeInputRequestBodySchema,
   EmailVerifyRequestBodySchema,
-  EmailVerifyResponseBodySchema,
   LoginRequestBodySchema,
   LoginResponseBodySchema,
   RegisterRequestBodySchema,
@@ -25,11 +24,6 @@ export const authApiPaths = {
       responses: {
         202: {
           description: '인증 코드 전송 성공',
-          content: {
-            'application/json': {
-              schema: EmailVerifyResponseBodySchema,
-            },
-          },
         },
       },
     },
@@ -46,11 +40,6 @@ export const authApiPaths = {
       responses: {
         202: {
           description: '인증 성공',
-          content: {
-            'application/json': {
-              schema: EmailVerifyResponseBodySchema,
-            },
-          },
         },
         400: {
           description: '코드 오류 또는 만료',
@@ -66,7 +55,7 @@ export const authApiPaths = {
 
   [`${currentApiPrefix}/register`]: {
     post: {
-      summary: '회원가입',
+      summary: '회원가입 (인증된 이메일 필요)',
       requestBody: {
         required: true,
         content: {

--- a/openapi/headers/index.ts
+++ b/openapi/headers/index.ts
@@ -1,0 +1,10 @@
+export const tokenHeader = {
+  name: 'Authorization',
+  in: 'header',
+  required: true,
+  schema: {
+    type: 'string',
+    example: 'Bearer <your-jwt-token>',
+  },
+  description: 'Bearer 토큰',
+};

--- a/openapi/index.ts
+++ b/openapi/index.ts
@@ -3,6 +3,9 @@ import { authApiPaths } from './auth';
 import fs from 'fs';
 import path from 'path';
 import yaml from 'yaml';
+import { institutionApiPaths } from './institution';
+import { markerApiPaths } from './marker';
+import { memberApiPaths } from './member';
 
 export const openApiDocument = createDocument({
   openapi: '3.1.0',
@@ -11,6 +14,20 @@ export const openApiDocument = createDocument({
     version: '1.0.0',
     description: '회원가입, 로그인, 이메일 인증 API 명세',
   },
+  components: {
+    securitySchemes: {
+      bearerAuth: {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+      },
+    },
+  },
+  security: [
+    {
+      bearerAuth: [],
+    },
+  ],
   servers: [
     {
       url: 'http://localhost:3000',
@@ -19,6 +36,9 @@ export const openApiDocument = createDocument({
   ],
   paths: {
     ...authApiPaths,
+    ...institutionApiPaths,
+    ...markerApiPaths,
+    ...memberApiPaths,
   },
 });
 

--- a/openapi/institution/index.ts
+++ b/openapi/institution/index.ts
@@ -1,0 +1,61 @@
+import { currentApiPrefix } from '../../src/constants';
+import {
+  GetInstitutionsResponseBodySchema,
+  GetInstitutionBoundsResponseBodySchema,
+} from '../../src/domains/institution/schema';
+import { ErrorSchema } from '../../src/domains/error/schema';
+import { tokenHeader } from '../headers';
+
+export const institutionApiPaths = {
+  [`${currentApiPrefix}/institutions`]: {
+    get: {
+      summary: '기관 목록 조회',
+      security: [{ bearerAuth: [] }],
+      parameters: [tokenHeader],
+      responses: {
+        200: {
+          description: '기관 목록 반환',
+          content: {
+            'application/json': {
+              schema: GetInstitutionsResponseBodySchema,
+            },
+          },
+        },
+        400: {
+          description: '요청 오류',
+          content: {
+            'application/json': {
+              schema: ErrorSchema,
+            },
+          },
+        },
+      },
+    },
+  },
+
+  [`${currentApiPrefix}/institutions/bounds`]: {
+    get: {
+      summary: '기관 경계 정보 조회',
+      security: [{ bearerAuth: [] }],
+      parameters: [tokenHeader],
+      responses: {
+        200: {
+          description: '기관 경계 정보 반환',
+          content: {
+            'application/json': {
+              schema: GetInstitutionBoundsResponseBodySchema,
+            },
+          },
+        },
+        400: {
+          description: '요청 오류',
+          content: {
+            'application/json': {
+              schema: ErrorSchema,
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/openapi/marker/index.ts
+++ b/openapi/marker/index.ts
@@ -1,0 +1,42 @@
+import { currentApiPrefix } from '../../src/constants';
+import {
+  GetMarkersResponseBodySchema,
+} from '../../src/domains/marker/schema';
+import { ErrorSchema } from '../../src/domains/error/schema';
+import { tokenHeader } from '../headers';
+
+export const markerApiPaths = {
+  [`${currentApiPrefix}/markers`]: {
+    get: {
+      summary: '마커 목록 조회',
+      security: [{ bearerAuth: [] }],
+      parameters: [tokenHeader],
+      responses: {
+        200: {
+          description: '마커 목록 반환',
+          content: {
+            'application/json': {
+              schema: GetMarkersResponseBodySchema,
+            },
+          },
+        },
+        400: {
+          description: '요청 오류',
+          content: {
+            'application/json': {
+              schema: ErrorSchema,
+            },
+          },
+        },
+        401: {
+          description: '인증 실패 (토큰 누락 또는 유효하지 않음)',
+          content: {
+            'application/json': {
+              schema: ErrorSchema,
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/openapi/member/index.ts
+++ b/openapi/member/index.ts
@@ -1,0 +1,34 @@
+import { currentApiPrefix } from '../../src/constants';
+import {
+  GetMyInfoSchema,
+} from '../../src/domains/member/schema';
+import { ErrorSchema } from '../../src/domains/error/schema';
+import { tokenHeader } from '../headers';
+
+export const memberApiPaths = {
+  [`${currentApiPrefix}/members/me`]: {
+    get: {
+      summary: '내 정보 조회',
+      security: [{ bearerAuth: [] }],
+      parameters: [tokenHeader],
+      responses: {
+        200: {
+          description: '회원 정보 반환',
+          content: {
+            'application/json': {
+              schema: GetMyInfoSchema
+            },
+          },
+        },
+        401: {
+          description: '인증 실패 (토큰 누락 또는 유효하지 않음)',
+          content: {
+            'application/json': {
+              schema: ErrorSchema,
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,13 +35,24 @@ model Post {
   title      String   @db.VarChar(255)
   content    String
   created_at DateTime @default(now())
-  latitude   Float
-  longitude  Float
+  expires_at DateTime
 
   author   Member     @relation(fields: [author_id], references: [id])
   chatroom ChatRoom[]
+  marker   Marker?    @relation("PostMarker")
 
   @@map("posts")
+}
+
+model Marker {
+  id        Int   @id @default(autoincrement())
+  post_id   Int   @unique
+  latitude  Float
+  longitude Float
+
+  post Post @relation("PostMarker", fields: [post_id], references: [id])
+
+  @@map("markers")
 }
 
 model ChatRoom {
@@ -86,4 +97,29 @@ model EmailVerification {
 
   @@index([email])
   @@map("verifications")
+}
+
+model Institution {
+  id           Int                @id @default(autoincrement())
+  name         String             @unique
+  email_domain String             @unique
+  is_active    Boolean            @default(true)
+  created_at   DateTime           @default(now())
+  updated_at   DateTime           @updatedAt
+  bounds       InstitutionBound[]
+
+  @@map("institutions")
+}
+
+model InstitutionBound {
+  id             Int      @id @default(autoincrement())
+  institution_id Int
+  latitude       Float
+  longitude      Float
+  created_at     DateTime @default(now())
+  updated_at     DateTime @updatedAt
+
+  institution Institution @relation(fields: [institution_id], references: [id], onDelete: Cascade)
+
+  @@map("institution_bounds")
 }

--- a/src/domains/auth/schema.ts
+++ b/src/domains/auth/schema.ts
@@ -10,8 +10,6 @@ export const EmailVerifyRequestBodySchema = z.object({
   email: z.string().email(),
 });
 
-export const EmailVerifyResponseBodySchema = z.object({});
-
 export const RegisterRequestBodySchema = z.object({
   email: z.string().email(),
   password: z.string(),

--- a/src/domains/auth/service.ts
+++ b/src/domains/auth/service.ts
@@ -7,7 +7,6 @@ import {
 import {
   EmailCodeInputRequest,
   EmailVerifyRequest,
-  EmailVerifyResponse,
   LoginRequest,
   LoginResponse,
   RegisterRequest,
@@ -22,7 +21,7 @@ import {
   EmailVerifyRequestBodySchema,
 } from '@/domains/auth/schema';
 
-export async function handleEmailCodeInput(req: EmailCodeInputRequest, res: EmailVerifyResponse) {
+export async function handleEmailCodeInput(req: EmailCodeInputRequest, res: Response) {
   try {
     const { email, code } = EmailCodeInputRequestBodySchema.parse(req.body);
     const targetEmail = await prisma.emailVerification.findFirst({

--- a/src/domains/auth/types.d.ts
+++ b/src/domains/auth/types.d.ts
@@ -6,7 +6,6 @@ import {
   LoginRequestBodySchema,
   LoginResponseBodySchema,
   RegisterRequestBodySchema,
-  EmailVerifyResponseBodySchema,
   RegisterResponseBodySchema,
 } from '@/domains/auth/schema';
 import { PasswordExcludedMemberSchema } from '@/domains/member/schema';
@@ -24,7 +23,6 @@ export interface AuthenticatedRequest<Params = {}, ReqBody = {}, ReqQuery = {}> 
 
 export type EmailCodeInputRequest = Request<{}, {}, z.infer<typeof EmailVerifyRequestBodySchema>>;
 export type EmailVerifyRequest = Request<{}, {}, z.infer<typeof EmailVerifyRequestBodySchema>>;
-export type EmailVerifyResponse = Response<z.infer<typeof EmailVerifyResponseBodySchema>>;
 
 export type RegisterRequest = Request<{}, {}, z.infer<typeof RegisterRequestBodySchema>>;
 export type LoginRequest = Request<{}, {}, z.infer<typeof LoginRequestBodySchema>>;

--- a/src/domains/error/schema.ts
+++ b/src/domains/error/schema.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+export const ErrorSchema = z.object({
+  message: z.string(),
+});

--- a/src/domains/institution/controller.ts
+++ b/src/domains/institution/controller.ts
@@ -7,7 +7,7 @@ import {
 const institutionRouter = express.Router();
 const routerPrefix = '/institutions';
 
-institutionRouter.get(`${routerPrefix}`, getInstitutions);
+institutionRouter.get(`${routerPrefix}`, getInstitutions); // TODO: Token Filter 추가
 institutionRouter.get(`${routerPrefix}/bounds`, getInstitutionBounds);
 
 export default institutionRouter;

--- a/src/domains/institution/controller.ts
+++ b/src/domains/institution/controller.ts
@@ -1,0 +1,13 @@
+import express from 'express';
+import {
+  getInstitutionBounds,
+  getInstitutions,
+} from '@/domains/institution/service';
+
+const institutionRouter = express.Router();
+const routerPrefix = '/institutions';
+
+institutionRouter.get(`${routerPrefix}`, getInstitutions);
+institutionRouter.get(`${routerPrefix}/bounds`, getInstitutionBounds);
+
+export default institutionRouter;

--- a/src/domains/institution/schema.ts
+++ b/src/domains/institution/schema.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+import { InstitutionBoundSchema, InstitutionSchema } from '@/schemas';
+
+export const GetInstitutionsRequestBodySchema = z.object({});
+export const GetInstitutionsResponseBodySchema = z.object({
+  institutions: z.array(InstitutionSchema.omit({
+    is_active: true,
+    created_at: true,
+    updated_at: true,
+  })),
+});
+export const GetInstitutionBoundsRequestBodySchema = z.object({});
+export const GetInstitutionBoundsResponseBodySchema = z.object({
+  bounds: z.array(InstitutionBoundSchema),
+});

--- a/src/domains/institution/schema.ts
+++ b/src/domains/institution/schema.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 import { InstitutionBoundSchema, InstitutionSchema } from '@/schemas';
 
-export const GetInstitutionsRequestBodySchema = z.object({});
 export const GetInstitutionsResponseBodySchema = z.object({
   institutions: z.array(InstitutionSchema.omit({
     is_active: true,
@@ -9,7 +8,7 @@ export const GetInstitutionsResponseBodySchema = z.object({
     updated_at: true,
   })),
 });
-export const GetInstitutionBoundsRequestBodySchema = z.object({});
+
 export const GetInstitutionBoundsResponseBodySchema = z.object({
   bounds: z.array(InstitutionBoundSchema),
 });

--- a/src/domains/institution/service.ts
+++ b/src/domains/institution/service.ts
@@ -1,19 +1,18 @@
 import {
-  GetInstitutionsRequest,
   GetInstitutionsResponse,
-  GetInstitutionBoundsRequest,
   GetInstitutionBoundsResponse,
 } from '@/domains/institution/types';
 import prisma from '@/utils/database';
+import { AuthenticatedRequest } from '@/domains/auth/types';
 
-export async function getInstitutions(_: GetInstitutionsRequest, res: GetInstitutionsResponse) {
+export async function getInstitutions(_: AuthenticatedRequest, res: GetInstitutionsResponse) {
   const institutions = await prisma.institution.findMany();
   res.json({
     institutions,
   });
 }
 
-export async function getInstitutionBounds(_: GetInstitutionBoundsRequest, res: GetInstitutionBoundsResponse) {
+export async function getInstitutionBounds(_: AuthenticatedRequest, res: GetInstitutionBoundsResponse) {
   const bounds = await prisma.institutionBound.findMany();
   res.json({
     bounds,

--- a/src/domains/institution/service.ts
+++ b/src/domains/institution/service.ts
@@ -1,0 +1,21 @@
+import {
+  GetInstitutionsRequest,
+  GetInstitutionsResponse,
+  GetInstitutionBoundsRequest,
+  GetInstitutionBoundsResponse,
+} from '@/domains/institution/types';
+import prisma from '@/utils/database';
+
+export async function getInstitutions(_: GetInstitutionsRequest, res: GetInstitutionsResponse) {
+  const institutions = await prisma.institution.findMany();
+  res.json({
+    institutions,
+  });
+}
+
+export async function getInstitutionBounds(_: GetInstitutionBoundsRequest, res: GetInstitutionBoundsResponse) {
+  const bounds = await prisma.institutionBound.findMany();
+  res.json({
+    bounds,
+  });
+}

--- a/src/domains/institution/types.d.ts
+++ b/src/domains/institution/types.d.ts
@@ -1,0 +1,14 @@
+import { Request, Response } from 'express';
+import {
+  GetInstitutionBoundsRequestBodySchema,
+  GetInstitutionBoundsResponseBodySchema,
+  GetInstitutionsRequestBodySchema,
+  GetInstitutionsResponseBodySchema,
+} from '@/domains/institution/schema';
+import { z } from 'zod';
+
+export type GetInstitutionsRequest = Request<{}, {}, z.infer<typeof GetInstitutionsRequestBodySchema>>;
+export type GetInstitutionsResponse = Response<z.infer<typeof GetInstitutionsResponseBodySchema>>;
+
+export type GetInstitutionBoundsRequest = Request<{}, {}, z.infer<typeof GetInstitutionBoundsRequestBodySchema>>;
+export type GetInstitutionBoundsResponse = Response<z.infer<typeof GetInstitutionBoundsResponseBodySchema>>;

--- a/src/domains/marker/controller.ts
+++ b/src/domains/marker/controller.ts
@@ -1,0 +1,10 @@
+import express from 'express';
+import { getMarkers } from '@/domains/marker/service';
+
+const routerPrefix = '/markers';
+
+const markerRouter = express.Router();
+
+markerRouter.get(`${routerPrefix}`, getMarkers); // TODO: Token Filter 추가
+
+export default markerRouter;

--- a/src/domains/marker/schema.ts
+++ b/src/domains/marker/schema.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 import { MarkerSchema, PostSchema } from '@/schemas';
 
-export const GetMarkersRequestBodySchema = z.object({});
 export const GetMarkersResponseBodySchema = z.object({
   markers: z.array(MarkerSchema.merge(
     PostSchema.pick({ expires_at: true })

--- a/src/domains/marker/schema.ts
+++ b/src/domains/marker/schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import { MarkerSchema, PostSchema } from '@/schemas';
+
+export const GetMarkersRequestBodySchema = z.object({});
+export const GetMarkersResponseBodySchema = z.object({
+  markers: z.array(MarkerSchema.merge(
+    PostSchema.pick({ expires_at: true })
+  )),
+});

--- a/src/domains/marker/service.ts
+++ b/src/domains/marker/service.ts
@@ -1,0 +1,24 @@
+import { GetMarkersRequest, GetMarkersResponse } from '@/domains/marker/types';
+import prisma from '@/utils/database';
+
+export async function getMarkers(_: GetMarkersRequest, res: GetMarkersResponse) {
+  const markers = await prisma.marker.findMany({
+    include: {
+      post: {
+        select: {
+          expires_at: true,
+        }
+      }
+    }
+  });
+  const flattened = markers.map(marker => ({
+    id: marker.id,
+    post_id: marker.post_id,
+    latitude: marker.latitude,
+    longitude: marker.longitude,
+    expires_at: marker.post?.expires_at ?? null,
+  }));
+  res.json({
+    markers: flattened,
+  });
+}

--- a/src/domains/marker/service.ts
+++ b/src/domains/marker/service.ts
@@ -1,7 +1,8 @@
-import { GetMarkersRequest, GetMarkersResponse } from '@/domains/marker/types';
+import { GetMarkersResponse } from '@/domains/marker/types';
 import prisma from '@/utils/database';
+import { AuthenticatedRequest } from '@/domains/auth/types';
 
-export async function getMarkers(_: GetMarkersRequest, res: GetMarkersResponse) {
+export async function getMarkers(_: AuthenticatedRequest, res: GetMarkersResponse) {
   const markers = await prisma.marker.findMany({
     include: {
       post: {

--- a/src/domains/marker/types.d.ts
+++ b/src/domains/marker/types.d.ts
@@ -1,9 +1,7 @@
-import { Request, Response } from 'express';
+import { Response } from 'express';
 import { z } from 'zod';
 import {
-  GetMarkersRequestBodySchema,
   GetMarkersResponseBodySchema,
 } from '@/domains/marker/schema';
 
-export type GetMarkersRequest = Request<{}, {}, z.infer<typeof GetMarkersRequestBodySchema>>;
 export type GetMarkersResponse = Response<z.infer<typeof GetMarkersResponseBodySchema>>;

--- a/src/domains/marker/types.d.ts
+++ b/src/domains/marker/types.d.ts
@@ -1,0 +1,9 @@
+import { Request, Response } from 'express';
+import { z } from 'zod';
+import {
+  GetMarkersRequestBodySchema,
+  GetMarkersResponseBodySchema,
+} from '@/domains/marker/schema';
+
+export type GetMarkersRequest = Request<{}, {}, z.infer<typeof GetMarkersRequestBodySchema>>;
+export type GetMarkersResponse = Response<z.infer<typeof GetMarkersResponseBodySchema>>;

--- a/src/domains/member/schema.ts
+++ b/src/domains/member/schema.ts
@@ -1,4 +1,8 @@
 // import { z } from 'zod';
 import { MemberSchema } from '@/schemas';
+import { z } from 'zod';
 
 export const PasswordExcludedMemberSchema = MemberSchema.omit({ password: true });
+export const GetMyInfoSchema = z.object({
+  member: PasswordExcludedMemberSchema,
+});

--- a/src/domains/member/service.ts
+++ b/src/domains/member/service.ts
@@ -1,9 +1,9 @@
 import { sendError } from '@/utils/network';
 import { StatusCodes } from 'http-status-codes';
-import { Response } from 'express';
 import { AuthenticatedRequest } from '@/domains/auth/types';
+import { GetMyInfoResponse } from '@/domains/member/types';
 
-export async function getMyInfo(req: AuthenticatedRequest, res: Response) {
+export async function getMyInfo(req: AuthenticatedRequest, res: GetMyInfoResponse) {
   if (!req.member) {
     sendError(res, '토큰이 필요합니다.', StatusCodes.UNAUTHORIZED);
     return;

--- a/src/domains/member/types.d.ts
+++ b/src/domains/member/types.d.ts
@@ -1,3 +1,6 @@
 import type { Member } from '.prisma/client';
+import type { Response } from 'express';
+import { GetMyInfoSchema } from '@/domains/member/schema';
 
 export type PasswordExcludedMember = Omit<Member, 'password'>;
+export type GetMyInfoResponse = Response<z.infer<typeof GetMyInfoSchema>>

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import logger from '@/utils/logger';
 import memberRouter from '@/domains/member/controller';
 import authRouter from '@/domains/auth/controller';
+import institutionRouter from '@/domains/institution/controller';
 import { currentApiPrefix } from '@/constants';
 import '@/utils/config';
 
@@ -14,6 +15,7 @@ app.use(express.json());
 
 app.use(API_PREFIX, authRouter);
 app.use(API_PREFIX, memberRouter);
+app.use(API_PREFIX, institutionRouter);
 
 // TODO: production, staging 환경에서 ssl 설정
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import logger from '@/utils/logger';
 import memberRouter from '@/domains/member/controller';
 import authRouter from '@/domains/auth/controller';
 import institutionRouter from '@/domains/institution/controller';
+import markerRouter from '@/domains/marker/controller';
 import { currentApiPrefix } from '@/constants';
 import '@/utils/config';
 
@@ -16,6 +17,7 @@ app.use(express.json());
 app.use(API_PREFIX, authRouter);
 app.use(API_PREFIX, memberRouter);
 app.use(API_PREFIX, institutionRouter);
+app.use(API_PREFIX, markerRouter);
 
 // TODO: production, staging 환경에서 ssl 설정
 

--- a/src/utils/config/index.ts
+++ b/src/utils/config/index.ts
@@ -1,5 +1,7 @@
 import dotenv from 'dotenv';
 
+const path = process.env.NODE_ENV === 'development' ? '.env' : `.env.${process.env.NODE_ENV}`;
+
 dotenv.config({
-  path: `.env.${process.env.NODE_ENV}`,
+  path
 });


### PR DESCRIPTION
# 변경점 👍
주로 프론트엔드 병목을 최소화하는 작업 위주로 진행했습니다.
- mock 데이터를 반환하는 엔드포인트 개발 (프론트엔드 병목 최소화 용)
- request dto에서 별도의 request body가 필요하지 않은 경우 빈 타입 `{}`을(를) 전달하던 문제점을 해결했습니다.
- GET 요청에 request body를 명시하던 문제점을 해결했습니다.
- 인증이 필요한 요청의 경우 인증 헤더에 대한 정보가 openapi 스펙에 포함되도록 했습니다.
