### PR TITLE
삭제 로직 변경 및 블랙리스트, 신고 구현 (ISSUE-67)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -677,9 +677,9 @@
         }
       }
     },
-    "/api/members/last_created": {
+    "/api/members/active_posts": {
       "get": {
-        "summary": "마지막 게시글 생성시간 조회",
+        "summary": "하루동안 생성한 게시글 개수 조회",
         "security": [
           {
             "bearerAuth": []
@@ -699,18 +699,18 @@
         ],
         "responses": {
           "200": {
-            "description": "최근 게시글 생성시간 반환",
+            "description": "24시간 이내 작성한 게시글 개수 반환",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "createdAt": {
-                      "type": "string"
+                    "count": {
+                      "type": "number"
                     }
                   },
                   "required": [
-                    "createdAt"
+                    "count"
                   ]
                 }
               }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -40,7 +40,7 @@
           }
         },
         "responses": {
-          "202": {
+          "201": {
             "description": "인증 코드 전송 성공"
           },
           "400": {
@@ -90,7 +90,7 @@
           }
         },
         "responses": {
-          "202": {
+          "201": {
             "description": "인증 성공"
           },
           "400": {
@@ -125,20 +125,28 @@
                 "type": "object",
                 "properties": {
                   "email": {
-                    "type": "string",
-                    "format": "email"
+                    "type": "string"
                   },
                   "password": {
                     "type": "string"
                   },
                   "name": {
                     "type": "string"
+                  },
+                  "birth": {
+                    "type": "string"
+                  },
+                  "termsAccepted": {
+                    "type": "boolean",
+                    "const": true
                   }
                 },
                 "required": [
                   "email",
                   "password",
-                  "name"
+                  "name",
+                  "birth",
+                  "termsAccepted"
                 ]
               }
             }
@@ -164,19 +172,31 @@
                         "name": {
                           "type": "string"
                         },
+                        "birth": {
+                          "type": "string"
+                        },
                         "joinedAt": {
                           "type": "string"
                         },
                         "reportedCount": {
                           "type": "integer"
+                        },
+                        "isDeactivated": {
+                          "type": "boolean"
+                        },
+                        "termsAccepted": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
                         "id",
                         "email",
                         "name",
+                        "birth",
                         "joinedAt",
-                        "reportedCount"
+                        "reportedCount",
+                        "isDeactivated",
+                        "termsAccepted"
                       ]
                     },
                     "token": {
@@ -258,19 +278,31 @@
                         "name": {
                           "type": "string"
                         },
+                        "birth": {
+                          "type": "string"
+                        },
                         "joinedAt": {
                           "type": "string"
                         },
                         "reportedCount": {
                           "type": "integer"
+                        },
+                        "isDeactivated": {
+                          "type": "boolean"
+                        },
+                        "termsAccepted": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
                         "id",
                         "email",
                         "name",
+                        "birth",
                         "joinedAt",
-                        "reportedCount"
+                        "reportedCount",
+                        "isDeactivated",
+                        "termsAccepted"
                       ]
                     },
                     "token": {
@@ -633,19 +665,31 @@
                         "name": {
                           "type": "string"
                         },
+                        "birth": {
+                          "type": "string"
+                        },
                         "joinedAt": {
                           "type": "string"
                         },
                         "reportedCount": {
                           "type": "integer"
+                        },
+                        "isDeactivated": {
+                          "type": "boolean"
+                        },
+                        "termsAccepted": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
                         "id",
                         "email",
                         "name",
+                        "birth",
                         "joinedAt",
-                        "reportedCount"
+                        "reportedCount",
+                        "isDeactivated",
+                        "termsAccepted"
                       ]
                     }
                   },
@@ -789,6 +833,9 @@
                         "null"
                       ]
                     },
+                    "isDeactivated": {
+                      "type": "boolean"
+                    },
                     "isWrittenBySelf": {
                       "type": "boolean"
                     }
@@ -801,6 +848,7 @@
                     "expiresAt",
                     "address",
                     "addressDetail",
+                    "isDeactivated",
                     "isWrittenBySelf"
                   ]
                 }
@@ -931,6 +979,9 @@
                       "null"
                     ]
                   },
+                  "isDeactivated": {
+                    "type": "boolean"
+                  },
                   "latitude": {
                     "type": "number"
                   },
@@ -943,6 +994,7 @@
                   "content",
                   "address",
                   "addressDetail",
+                  "isDeactivated",
                   "latitude",
                   "longitude"
                 ]
@@ -975,6 +1027,107 @@
           },
           "400": {
             "description": "요청 오류",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/reports": {
+      "post": {
+        "summary": "신고 등록",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": true,
+            "description": "Bearer 토큰",
+            "schema": {
+              "type": "string",
+              "example": "Bearer <your-jwt-token>"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "reportType": {
+                    "type": "string",
+                    "enum": [
+                      "POST_REPORT",
+                      "CHATROOM_REPORT"
+                    ]
+                  },
+                  "postId": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "chatroomId": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "reportType",
+                  "reason"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "신고 등록 성공"
+          },
+          "400": {
+            "description": "잘못된 요청 또는 자기 자신 신고 시도",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "대상 사용자를 찾을 수 없음",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -430,9 +430,9 @@ paths:
                     type: string
                 required:
                   - message
-  /api/members/last_created:
+  /api/members/active_posts:
     get:
-      summary: 마지막 게시글 생성시간 조회
+      summary: 하루동안 생성한 게시글 개수 조회
       security:
         - bearerAuth: []
       parameters:
@@ -445,16 +445,16 @@ paths:
             example: Bearer <your-jwt-token>
       responses:
         "200":
-          description: 최근 게시글 생성시간 반환
+          description: 24시간 이내 작성한 게시글 개수 반환
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  createdAt:
-                    type: string
+                  count:
+                    type: number
                 required:
-                  - createdAt
+                  - count
         "401":
           description: 인증 실패 (토큰 누락 또는 유효하지 않음)
           content:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -25,7 +25,7 @@ paths:
               required:
                 - email
       responses:
-        "202":
+        "201":
           description: 인증 코드 전송 성공
         "400":
           description: 등록되지 않은 이메일 도메인
@@ -57,7 +57,7 @@ paths:
                 - email
                 - code
       responses:
-        "202":
+        "201":
           description: 인증 성공
         "400":
           description: 코드 오류 또는 만료
@@ -82,15 +82,21 @@ paths:
               properties:
                 email:
                   type: string
-                  format: email
                 password:
                   type: string
                 name:
                   type: string
+                birth:
+                  type: string
+                termsAccepted:
+                  type: boolean
+                  const: true
               required:
                 - email
                 - password
                 - name
+                - birth
+                - termsAccepted
       responses:
         "200":
           description: 회원가입 성공
@@ -108,16 +114,25 @@ paths:
                         type: string
                       name:
                         type: string
+                      birth:
+                        type: string
                       joinedAt:
                         type: string
                       reportedCount:
                         type: integer
+                      isDeactivated:
+                        type: boolean
+                      termsAccepted:
+                        type: boolean
                     required:
                       - id
                       - email
                       - name
+                      - birth
                       - joinedAt
                       - reportedCount
+                      - isDeactivated
+                      - termsAccepted
                   token:
                     type: string
                 required:
@@ -169,16 +184,25 @@ paths:
                         type: string
                       name:
                         type: string
+                      birth:
+                        type: string
                       joinedAt:
                         type: string
                       reportedCount:
                         type: integer
+                      isDeactivated:
+                        type: boolean
+                      termsAccepted:
+                        type: boolean
                     required:
                       - id
                       - email
                       - name
+                      - birth
                       - joinedAt
                       - reportedCount
+                      - isDeactivated
+                      - termsAccepted
                   token:
                     type: string
                 required:
@@ -407,16 +431,25 @@ paths:
                         type: string
                       name:
                         type: string
+                      birth:
+                        type: string
                       joinedAt:
                         type: string
                       reportedCount:
                         type: integer
+                      isDeactivated:
+                        type: boolean
+                      termsAccepted:
+                        type: boolean
                     required:
                       - id
                       - email
                       - name
+                      - birth
                       - joinedAt
                       - reportedCount
+                      - isDeactivated
+                      - termsAccepted
                 required:
                   - member
         "401":
@@ -503,6 +536,8 @@ paths:
                     type:
                       - string
                       - "null"
+                  isDeactivated:
+                    type: boolean
                   isWrittenBySelf:
                     type: boolean
                 required:
@@ -513,6 +548,7 @@ paths:
                   - expiresAt
                   - address
                   - addressDetail
+                  - isDeactivated
                   - isWrittenBySelf
         "404":
           description: 게시글 없음
@@ -592,6 +628,8 @@ paths:
                   type:
                     - string
                     - "null"
+                isDeactivated:
+                  type: boolean
                 latitude:
                   type: number
                 longitude:
@@ -601,6 +639,7 @@ paths:
                 - content
                 - address
                 - addressDetail
+                - isDeactivated
                 - latitude
                 - longitude
       responses:
@@ -620,6 +659,69 @@ paths:
                   - markerId
         "400":
           description: 요청 오류
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+  /api/reports:
+    post:
+      summary: 신고 등록
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: header
+          name: Authorization
+          required: true
+          description: Bearer 토큰
+          schema:
+            type: string
+            example: Bearer <your-jwt-token>
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reportType:
+                  type: string
+                  enum:
+                    - POST_REPORT
+                    - CHATROOM_REPORT
+                postId:
+                  type:
+                    - integer
+                    - "null"
+                chatroomId:
+                  type:
+                    - integer
+                    - "null"
+                reason:
+                  type: string
+              required:
+                - reportType
+                - reason
+      responses:
+        "201":
+          description: 신고 등록 성공
+        "400":
+          description: 잘못된 요청 또는 자기 자신 신고 시도
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
+        "404":
+          description: 대상 사용자를 찾을 수 없음
           content:
             application/json:
               schema:

--- a/openapi/auth/index.ts
+++ b/openapi/auth/index.ts
@@ -22,7 +22,7 @@ export const authApiPaths = {
         },
       },
       responses: {
-        202: {
+        201: {
           description: '인증 코드 전송 성공',
         },
         400: {
@@ -46,7 +46,7 @@ export const authApiPaths = {
         },
       },
       responses: {
-        202: {
+        201: {
           description: '인증 성공',
         },
         400: {

--- a/openapi/index.ts
+++ b/openapi/index.ts
@@ -7,6 +7,7 @@ import { institutionApiPaths } from './institution';
 import { markerApiPaths } from './marker';
 import { memberApiPaths } from './member';
 import { postApiPaths } from './post';
+import { reportApiPaths } from './report';
 
 export const openApiDocument = createDocument({
   openapi: '3.1.0',
@@ -41,6 +42,7 @@ export const openApiDocument = createDocument({
     ...markerApiPaths,
     ...memberApiPaths,
     ...postApiPaths,
+    ...reportApiPaths,
   },
 });
 

--- a/openapi/member/index.ts
+++ b/openapi/member/index.ts
@@ -2,7 +2,7 @@ import { currentApiPrefix } from '../../src/constants';
 import { tokenHeader } from '../headers';
 import {
   GetMyInfoSchema,
-  GetLastPostResponseBodySchema,
+  GetActivePostCountResponseBodySchema,
 } from '../../src/domains/member/schema';
 import { ErrorSchema } from '../../src/domains/error/schema';
 
@@ -33,17 +33,17 @@ export const memberApiPaths = {
     },
   },
 
-  [`${currentApiPrefix}/members/last_created`]: {
+  [`${currentApiPrefix}/members/active_posts`]: {
     get: {
-      summary: '마지막 게시글 생성시간 조회',
+      summary: '하루동안 생성한 게시글 개수 조회',
       security: [{ bearerAuth: [] }],
       parameters: [tokenHeader],
       responses: {
         200: {
-          description: '최근 게시글 생성시간 반환',
+          description: '24시간 이내 작성한 게시글 개수 반환',
           content: {
             'application/json': {
-              schema: GetLastPostResponseBodySchema,
+              schema: GetActivePostCountResponseBodySchema,
             },
           },
         },

--- a/openapi/report/index.ts
+++ b/openapi/report/index.ts
@@ -1,0 +1,43 @@
+import { currentApiPrefix } from '../../src/constants';
+import { CreateReportRequestBodySchema } from '../../src/domains/report/schema';
+import { ErrorSchema } from '../../src/domains/error/schema';
+import { tokenHeader } from '../headers';
+
+export const reportApiPaths = {
+  [`${currentApiPrefix}/reports`]: {
+    post: {
+      summary: '신고 등록',
+      security: [{ bearerAuth: [] }],
+      parameters: [tokenHeader],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: CreateReportRequestBodySchema,
+          },
+        },
+      },
+      responses: {
+        201: {
+          description: '신고 등록 성공',
+        },
+        400: {
+          description: '잘못된 요청 또는 자기 자신 신고 시도',
+          content: {
+            'application/json': {
+              schema: ErrorSchema,
+            },
+          },
+        },
+        404: {
+          description: '대상 사용자를 찾을 수 없음',
+          content: {
+            'application/json': {
+              schema: ErrorSchema,
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "typescript-eslint": "^8.29.0",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.0.9",
+    "vitest-mock-extended": "^3.1.0",
     "yaml": "^2.7.1",
     "zod-openapi": "^4.2.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       vitest:
         specifier: ^3.0.9
         version: 3.0.9(@types/node@22.13.10)(jiti@1.21.7)(tsx@4.19.3)(yaml@2.7.1)
+      vitest-mock-extended:
+        specifier: ^3.1.0
+        version: 3.1.0(typescript@5.8.2)(vitest@3.0.9(@types/node@22.13.10)(jiti@1.21.7)(tsx@4.19.3)(yaml@2.7.1))
       yaml:
         specifier: ^2.7.1
         version: 2.7.1
@@ -1869,6 +1872,14 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-essentials@10.0.4:
+    resolution: {integrity: sha512-lwYdz28+S4nicm+jFi6V58LaAIpxzhg9rLdgNC1VsdP/xiFBseGhF1M/shwCk6zMmwahBZdXcl34LVHrEang3A==}
+    peerDependencies:
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   tsc-alias@1.8.11:
     resolution: {integrity: sha512-2DuEQ58A9Rj2NE2c1+/qaGKlshni9MCK95MJzRGhQG0CYLw0bE/ACgbhhTSf/p1svLelwqafOd8stQate2bYbg==}
     hasBin: true
@@ -1992,6 +2003,12 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  vitest-mock-extended@3.1.0:
+    resolution: {integrity: sha512-vCM0VkuocOUBwwqwV7JB7YStw07pqeKvEIrZnR8l3PtwYi6rAAJAyJACeC1UYNfbQWi85nz7EdiXWBFI5hll2g==}
+    peerDependencies:
+      typescript: 3.x || 4.x || 5.x
+      vitest: '>=3.0.0'
 
   vitest@3.0.9:
     resolution: {integrity: sha512-BbcFDqNyBlfSpATmTtXOAOj71RNKDDvjBM/uPfnxxVGrG+FSH2RQIwgeEngTaTkuU/h0ScFvf+tRcKfYXzBybQ==}
@@ -4310,6 +4327,10 @@ snapshots:
     dependencies:
       typescript: 5.8.2
 
+  ts-essentials@10.0.4(typescript@5.8.2):
+    optionalDependencies:
+      typescript: 5.8.2
+
   tsc-alias@1.8.11:
     dependencies:
       chokidar: 3.6.0
@@ -4418,6 +4439,12 @@ snapshots:
       jiti: 1.21.7
       tsx: 4.19.3
       yaml: 2.7.1
+
+  vitest-mock-extended@3.1.0(typescript@5.8.2)(vitest@3.0.9(@types/node@22.13.10)(jiti@1.21.7)(tsx@4.19.3)(yaml@2.7.1)):
+    dependencies:
+      ts-essentials: 10.0.4(typescript@5.8.2)
+      typescript: 5.8.2
+      vitest: 3.0.9(@types/node@22.13.10)(jiti@1.21.7)(tsx@4.19.3)(yaml@2.7.1)
 
   vitest@3.0.9(@types/node@22.13.10)(jiti@1.21.7)(tsx@4.19.3)(yaml@2.7.1):
     dependencies:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,7 @@ model Member {
   password      String   @map("password") @db.VarChar(88)
   joinedAt      DateTime @default(now()) @map("joined_at")
   reportedCount Int      @default(0) @map("reported_count")
+  isDeactivated Boolean  @default(false)
 
   posts              Post[]
   authoredChatRooms  ChatRoom[] @relation("AuthoredRooms")
@@ -41,10 +42,11 @@ model Post {
   expiresAt     DateTime @map("expires_at")
   address       String   @map("address") @db.VarChar(255)
   addressDetail String?  @map("address_detail") @db.VarChar(255)
+  isDeactivated Boolean  @default(false) @map("is_deactivated")
 
-  author   Member     @relation(fields: [authorId], references: [id], onDelete: Cascade)
+  author   Member     @relation(fields: [authorId], references: [id])
   chatroom ChatRoom[]
-  marker   Marker?    @relation("PostMarker")
+  marker   Marker?
   reports  Report[]
 
   @@map("posts")
@@ -56,7 +58,7 @@ model Marker {
   latitude  Float @map("latitude")
   longitude Float @map("longitude")
 
-  post Post @relation("PostMarker", fields: [postId], references: [id])
+  post Post @relation(fields: [postId], references: [id])
 
   @@map("markers")
 }
@@ -69,6 +71,7 @@ model ChatRoom {
   createdAt         DateTime @default(now()) @map("created_at")
   authorNickname    String   @map("author_nickname") @db.VarChar(20)
   requesterNickname String   @map("requester_nickname") @db.VarChar(20)
+  isDeactivated     Boolean  @default(false) @map("is_deactivated")
 
   post      Post     @relation(fields: [postId], references: [id])
   author    Member   @relation("AuthoredRooms", fields: [authorId], references: [id])
@@ -106,6 +109,16 @@ model EmailVerification {
   @@map("verifications")
 }
 
+model Blacklist {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique @db.VarChar(255)
+  createdAt DateTime @default(now()) @map("created_at")
+  memberId  Int      @map("member_id")
+
+  @@index([email])
+  @@map("blacklists")
+}
+
 model Institution {
   id          Int                @id @default(autoincrement()) @map("id")
   name        String             @unique @map("name")
@@ -141,6 +154,7 @@ model Report {
   reporterId Int        @map("reporter_id")
   reportedId Int        @map("reported_id")
   createdAt  DateTime   @default(now()) @map("created_at")
+  reason     String     @db.VarChar(255)
 
   post     Post?     @relation(fields: [postId], references: [id])
   chatroom ChatRoom? @relation(fields: [chatroomId], references: [id])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,9 +18,11 @@ model Member {
   email         String   @unique @map("email") @db.VarChar(255)
   name          String   @map("name") @db.VarChar(20)
   password      String   @map("password") @db.VarChar(88)
+  birth         DateTime @default(now())
   joinedAt      DateTime @default(now()) @map("joined_at")
   reportedCount Int      @default(0) @map("reported_count")
-  isDeactivated Boolean  @default(false)
+  isDeactivated Boolean  @default(false) @map("is_deactivated")
+  termsAccepted Boolean  @default(false) @map("terms_accepted")
 
   posts              Post[]
   authoredChatRooms  ChatRoom[] @relation("AuthoredRooms")

--- a/src/domains/auth/middleware.ts
+++ b/src/domains/auth/middleware.ts
@@ -54,6 +54,11 @@ export async function authMiddleware(
       sendError(res, '토큰 검증 실패', StatusCodes.UNAUTHORIZED);
       return;
     }
+    
+    if (member.isDeactivated) {
+      sendError(res, '탈퇴한 사용자의 인증 정보입니다.', StatusCodes.FORBIDDEN);
+      return;
+    }
 
     req.member = member;
     next();

--- a/src/domains/auth/schema.ts
+++ b/src/domains/auth/schema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { PasswordExcludedMemberSchema } from '@/domains/member/schema';
+import { MemberSchema } from '@/schemas';
 
 export const EmailCodeInputRequestBodySchema = z.object({
   email: z.string().email(),
@@ -10,10 +11,15 @@ export const EmailVerifyRequestBodySchema = z.object({
   email: z.string().email(),
 });
 
-export const RegisterRequestBodySchema = z.object({
-  email: z.string().email(),
-  password: z.string(),
-  name: z.string(),
+export const RegisterRequestBodySchema = MemberSchema.pick({
+  email: true,
+  password: true,
+  name: true,
+}).extend({
+  birth: z.coerce.date()
+    .min(new Date('1990-01-01'))
+    .max(new Date(new Date().getFullYear() - 20, 0, 1)),
+  termsAccepted: z.literal(true),
 });
 
 export const LoginRequestBodySchema = z.object({

--- a/src/domains/auth/service.ts
+++ b/src/domains/auth/service.ts
@@ -21,6 +21,7 @@ import { getPasswordExcludedMember } from '@/domains/member/utils';
 import {
   EmailCodeInputRequestBodySchema,
   EmailVerifyRequestBodySchema,
+  RegisterRequestBodySchema,
 } from '@/domains/auth/schema';
 
 export async function handleEmailCodeInput(req: EmailCodeInputRequest, res: Response) {
@@ -88,9 +89,8 @@ export async function handleEmailVerifyRequest(req: EmailVerifyRequest, res: Res
 }
 
 export async function handleRegister(req: RegisterRequest, res: RegisterResponse) {
-  const { email, name, password } = req.body;
-
   try {
+    const { email, name, password, birth, termsAccepted } = RegisterRequestBodySchema.parse(req.body);
     const blacklisted = await prisma.blacklist.findFirst({
       where: {
         email
@@ -128,6 +128,8 @@ export async function handleRegister(req: RegisterRequest, res: RegisterResponse
       data: {
         email,
         name,
+        birth,
+        termsAccepted,
         password: hashedPassword,
       },
     });

--- a/src/domains/member/controller.ts
+++ b/src/domains/member/controller.ts
@@ -1,12 +1,12 @@
 import express from 'express';
 import { authMiddleware } from '@/domains/auth/middleware';
-import { getLastCreatedPost, getMyInfo } from '@/domains/member/service';
+import { getActivePostCount, getMyInfo } from '@/domains/member/service';
 
 const memberRouter = express.Router();
 
 const ROUTE_PREFIX = '/members';
 
 memberRouter.get(`${ROUTE_PREFIX}/me`, authMiddleware, getMyInfo);
-memberRouter.get(`${ROUTE_PREFIX}/last_created`, authMiddleware, getLastCreatedPost);
+memberRouter.get(`${ROUTE_PREFIX}/active_posts`, authMiddleware, getActivePostCount);
 
 export default memberRouter;

--- a/src/domains/member/schema.ts
+++ b/src/domains/member/schema.ts
@@ -1,4 +1,4 @@
-import { MemberSchema, PostSchema } from '@/schemas';
+import { MemberSchema} from '@/schemas';
 import { z } from 'zod';
 
 export const PasswordExcludedMemberSchema = MemberSchema.omit({ password: true });
@@ -6,6 +6,6 @@ export const GetMyInfoSchema = z.object({
   member: PasswordExcludedMemberSchema,
 });
 
-export const GetLastPostResponseBodySchema = PostSchema.pick({
-  createdAt: true,
+export const GetActivePostCountResponseBodySchema = z.object({
+  count: z.number()
 });

--- a/src/domains/member/service.ts
+++ b/src/domains/member/service.ts
@@ -32,6 +32,7 @@ export async function deactivateMember(member: Member | number) {
       email: '',
       name: '탈퇴한 사용자',
       password: '',
+      birth: new Date('1970-01-01'),
       isDeactivated: true,
     }
   });

--- a/src/domains/member/service.ts
+++ b/src/domains/member/service.ts
@@ -1,27 +1,20 @@
 import { AuthenticatedRequest } from '@/domains/auth/types';
-import { GetLastPostResponse, GetMyInfoResponse } from '@/domains/member/types';
+import { GetActivePostCountResponse, GetMyInfoResponse } from '@/domains/member/types';
 import prisma from '@/utils/database';
 
 export async function getMyInfo(req: AuthenticatedRequest, res: GetMyInfoResponse) {
   res.json({ member: req.member });
 }
 
-export async function getLastCreatedPost(req: AuthenticatedRequest, res: GetLastPostResponse) {
+export async function getActivePostCount(req: AuthenticatedRequest, res: GetActivePostCountResponse) {
   const memberId = req.member?.id as number;
-  const createdAt = await prisma.post.findFirst({
+  const count = await prisma.post.count({
     where: {
       authorId: memberId,
-    },
-    select: {
-      createdAt: true,
-    },
-    orderBy: {
-      createdAt: 'desc',
+      expiresAt: {
+        gt: new Date(),
+      }
     }
   });
-  if(! createdAt) {
-    res.json({ createdAt: new Date('1970-01-01') });
-    return;
-  }
-  res.json(createdAt);
+  res.json({ count });
 }

--- a/src/domains/member/service.ts
+++ b/src/domains/member/service.ts
@@ -1,6 +1,7 @@
 import { AuthenticatedRequest } from '@/domains/auth/types';
 import { GetActivePostCountResponse, GetMyInfoResponse } from '@/domains/member/types';
 import prisma from '@/utils/database';
+import { Member } from '.prisma/client';
 
 export async function getMyInfo(req: AuthenticatedRequest, res: GetMyInfoResponse) {
   res.json({ member: req.member });
@@ -17,4 +18,21 @@ export async function getActivePostCount(req: AuthenticatedRequest, res: GetActi
     }
   });
   res.json({ count });
+}
+
+export async function deactivateMember(member: Member | number) {
+  if(typeof member !== 'number') {
+    member = member.id;
+  }
+  await prisma.member.update({
+    where: {
+      id: member,
+    },
+    data: {
+      email: '',
+      name: '탈퇴한 사용자',
+      password: '',
+      isDeactivated: true,
+    }
+  });
 }

--- a/src/domains/member/types.d.ts
+++ b/src/domains/member/types.d.ts
@@ -1,11 +1,11 @@
 import type { Member } from '.prisma/client';
 import type { Response } from 'express';
 import {
-  GetLastPostResponseBodySchema,
+  GetActivePostCountResponseBodySchema,
   GetMyInfoSchema,
 } from '@/domains/member/schema';
 
 export type PasswordExcludedMember = Omit<Member, 'password'>;
 export type GetMyInfoResponse = Response<z.infer<typeof GetMyInfoSchema>>
 
-export type GetLastPostResponse = Response<z.infer<typeof GetLastPostResponseBodySchema>>;
+export type GetActivePostCountResponse = Response<z.infer<typeof GetActivePostCountResponseBodySchema>>;

--- a/src/domains/post/service.ts
+++ b/src/domains/post/service.ts
@@ -22,7 +22,8 @@ export async function getPost(req: GetPostRequest, res: GetPostResponse) {
     const { postId } = GetPostPathSchema.parse(req.params);
     const post = await prisma.post.findUnique({
       where: {
-        id: postId
+        id: postId,
+        isDeactivated: false,
       },
     });
     if (!post) {
@@ -56,6 +57,14 @@ export async function deletePost(req: DeletePostRequest, res: Response) {
       sendError(res, '삭제 권한이 없습니다.', StatusCodes.BAD_REQUEST);
       return;
     }
+    await prisma.post.update({
+      where: {
+        id: post.id,
+      },
+      data: {
+        isDeactivated: true,
+      }
+    });
     res.json({ message: '삭제가 완료되었습니다.' });
   } catch(error) {
     sendAndTrace(res, error);

--- a/src/domains/report/controller.ts
+++ b/src/domains/report/controller.ts
@@ -1,0 +1,11 @@
+import express from 'express';
+import { createReport } from '@/domains/report/service';
+import { authMiddleware } from '@/domains/auth/middleware';
+
+const reportRouter = express.Router();
+
+const apiPrefix = '/reports';
+
+reportRouter.post(apiPrefix, authMiddleware, createReport);
+
+export default reportRouter;

--- a/src/domains/report/schema.ts
+++ b/src/domains/report/schema.ts
@@ -1,0 +1,11 @@
+import { ReportSchema } from '@/schemas';
+
+export const CreateReportRequestBodySchema = ReportSchema.omit({
+  id: true,
+  createdAt: true,
+  reportedId: true,
+  reporterId: true,
+}).partial({
+  chatroomId: true,
+  postId: true,
+});

--- a/src/domains/report/service.ts
+++ b/src/domains/report/service.ts
@@ -1,0 +1,96 @@
+import { CreateReportRequest } from '@/domains/report/types';
+import { Response } from 'express';
+import { CreateReportRequestBodySchema } from '@/domains/report/schema';
+import { sendAndTrace, sendError } from '@/utils/network';
+import { StatusCodes } from 'http-status-codes';
+import { z } from 'zod';
+import { PasswordExcludedMember } from '@/domains/member/types';
+import prisma from '@/utils/database';
+import { Member } from '.prisma/client';
+import { deactivateMember } from '@/domains/member/service';
+
+export async function createReport(req: CreateReportRequest, res: Response) {
+  try {
+    const createInput = CreateReportRequestBodySchema.parse(req.body);
+    const reportType = createInput.reportType;
+    if((reportType === 'CHATROOM_REPORT' && ! createInput.chatroomId)
+      || (reportType === 'POST_REPORT' && ! createInput.postId)) {
+      sendError(res, '잘못된 요청입니다.', StatusCodes.BAD_REQUEST);
+      return;
+    }
+    const reportedId = await getReportedMemberId(createInput, req.member!);
+    const reporterId = req.member!.id;
+    if(! reportedId) {
+      sendError(res, '이미 탈퇴한 사용자이거나, 없는 게시글(채팅방)입니다.', StatusCodes.NOT_FOUND);
+      return;
+    }
+    if(reportedId === reporterId) {
+      sendError(res, '자기 자신이 작성한 글은 신고할 수 없습니다.', StatusCodes.BAD_REQUEST);
+      return;
+    }
+    await prisma.report.create({
+      data: {
+        ...createInput,
+        reporterId,
+        reportedId,
+      }
+    });
+    const updateResult = await prisma.member.update({
+      where: {
+        id: reportedId,
+      },
+      data: {
+        reportedCount: {
+          increment: 1,
+        }
+      }
+    });
+    await handleReportIncrement(updateResult);
+    res.status(StatusCodes.CREATED).send();
+  } catch(error) {
+    sendAndTrace(res, error);
+  }
+}
+
+async function handleReportIncrement(updateResult: Member) {
+  // 경고 5회 이상일 경우 계정 삭제 및 블랙리스트 등록
+  if(updateResult.reportedCount >= 5) {
+    // 이미 블랙리스트인 경우
+    if(await prisma.blacklist.count({ where: { email: updateResult.email } }))
+      return;
+    await prisma.blacklist.create({
+      data: {
+        email: updateResult.email,
+        memberId: updateResult.id,
+      }
+    });
+    await deactivateMember(updateResult);
+  }
+}
+
+async function getReportedMemberId(createInput: z.infer<typeof CreateReportRequestBodySchema>, reporter: PasswordExcludedMember) {
+  let reportedId = 0;
+  if(createInput.reportType === 'CHATROOM_REPORT') {
+    // 채팅방 신고의 경우 채팅 요청자나 채팅 작성자 모두 신고당할 수 있음
+    const chatRoom = await prisma.chatRoom.findUnique({
+      where: {
+        id: createInput.chatroomId as number
+      }
+    });
+    if(! chatRoom) {
+      return reportedId;
+    }
+    reportedId = chatRoom.authorId === reporter.id ? chatRoom.requesterId : chatRoom.authorId;
+  } else { // 게시글 신고의 경우 신고받은 사람은 게시글 작성자
+    const post = await prisma.post.findUnique({
+      where: {
+        id: createInput.postId as number
+      }
+    });
+    if(! post) {
+      return reportedId;
+    }
+    reportedId = post.authorId;
+  }
+  return reportedId;
+}

--- a/src/domains/report/types.d.ts
+++ b/src/domains/report/types.d.ts
@@ -1,0 +1,4 @@
+import { AuthenticatedRequest } from '@/domains/auth/types';
+import { CreateReportRequestBodySchema } from '@/domains/report/schema';
+
+export type CreateReportRequest = AuthenticatedRequest<z.infer<typeof CreateReportRequestBodySchema>>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,11 @@ import memberRouter from '@/domains/member/controller';
 import authRouter from '@/domains/auth/controller';
 import institutionRouter from '@/domains/institution/controller';
 import markerRouter from '@/domains/marker/controller';
+import postRouter from '@/domains/post/controller';
+import reportRouter from '@/domains/report/controller';
 import { currentApiPrefix } from '@/constants';
 import swaggerUi from 'swagger-ui-express';
 import '@/utils/config';
-import postRouter from '@/domains/post/controller';
 import path from 'path';
 import fs from 'fs';
 
@@ -23,6 +24,7 @@ app.use(API_PREFIX, memberRouter);
 app.use(API_PREFIX, institutionRouter);
 app.use(API_PREFIX, markerRouter);
 app.use(API_PREFIX, postRouter);
+app.use(API_PREFIX, reportRouter);
 
 app.get('/', (_, res) => {
   res.send('Hello, Express!');

--- a/src/utils/network/index.ts
+++ b/src/utils/network/index.ts
@@ -11,6 +11,7 @@ export function sendError(res: Response, message: string, errorCode: number = St
 export function sendAndTrace(res: Response, error: any) {
   if(error instanceof z.ZodError) {
     sendError(res, '잘못된 요청입니다.', StatusCodes.BAD_REQUEST);
+    console.error(error);
     return;
   }
   sendError(res, '서버 에러가 발생했습니다.');

--- a/src/utils/redis/index.ts
+++ b/src/utils/redis/index.ts
@@ -1,0 +1,9 @@
+import '@/utils/config';
+import Redis from 'ioredis';
+
+const redis = new Redis(process.env.REDIS_URL as string);
+export default redis;
+
+export const pub = new Redis(process.env.REDIS_URL as string);
+export const sub = new Redis(process.env.REDIS_URL as string);
+

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,15 @@
+import { PrismaClient } from '@prisma/client';
+import { mockDeep, mockReset, DeepMockProxy } from 'vitest-mock-extended';
+import prisma from './src/utils/database';
+import { beforeEach, vi } from 'vitest';
+
+vi.mock('./src/utils/database', () => ({
+  __esModule: true,
+  default: mockDeep<PrismaClient>(),
+}));
+
+beforeEach(() => {
+  mockReset(prismaMock);
+});
+
+export const prismaMock = prisma as unknown as DeepMockProxy<PrismaClient>;


### PR DESCRIPTION
# 변경점 👍

- 신고 기능과 블랙리스트를 구현했습니다.
  - 신고 5회 누적 시 블랙리스트에 자동으로 등록되며 재가입이 제한됩니다.
  - 게시글이나 1대1채팅방을 신고할 수 있습니다.
- 회원가입시 생년월일과 termsAccepted 필드를 추가로 받도록 변경했습니다.
- 사용자와 게시글의 삭제 정책을 isDeactivated 필드를 통한 soft delete로 변경했습니다. 사용자 정보의 경우 이메일과 패스워드를 빈 문자열로 대체하고 '탈퇴한 사용자'라는 이름을 갖도록 변경했습니다.
- 테스트를 위한 mock prisma client를 작성했습니다.