### PR TITLE
게시글 생성 시 길이 제한 설정 및 스키마 수정 (ISSUE-70)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -973,22 +973,20 @@
                 "type": "object",
                 "properties": {
                   "title": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 63
                   },
                   "content": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 255
                   },
                   "address": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 63
                   },
                   "addressDetail": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "isDeactivated": {
-                    "type": "boolean"
+                    "type": "string",
+                    "maxLength": 63
                   },
                   "latitude": {
                     "type": "number"
@@ -1002,7 +1000,6 @@
                   "content",
                   "address",
                   "addressDetail",
-                  "isDeactivated",
                   "latitude",
                   "longitude"
                 ]

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -626,16 +626,16 @@ paths:
               properties:
                 title:
                   type: string
+                  maxLength: 63
                 content:
                   type: string
+                  maxLength: 255
                 address:
                   type: string
+                  maxLength: 63
                 addressDetail:
-                  type:
-                    - string
-                    - "null"
-                isDeactivated:
-                  type: boolean
+                  type: string
+                  maxLength: 63
                 latitude:
                   type: number
                 longitude:
@@ -645,7 +645,6 @@ paths:
                 - content
                 - address
                 - addressDetail
-                - isDeactivated
                 - latitude
                 - longitude
       responses:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,12 +38,12 @@ model Member {
 model Post {
   id            Int      @id @default(autoincrement()) @map("id")
   authorId      Int      @map("author_id")
-  title         String   @map("title") @db.VarChar(255)
-  content       String   @map("content")
+  title         String   @map("title") @db.VarChar(63)
+  content       String   @map("content") @db.VarChar(255)
   createdAt     DateTime @default(now()) @map("created_at")
   expiresAt     DateTime @map("expires_at")
-  address       String   @map("address") @db.VarChar(255)
-  addressDetail String?  @map("address_detail") @db.VarChar(255)
+  address       String   @map("address") @db.VarChar(63)
+  addressDetail String?  @map("address_detail") @db.VarChar(63)
   isDeactivated Boolean  @default(false) @map("is_deactivated")
 
   author   Member     @relation(fields: [authorId], references: [id])

--- a/src/domains/post/schema.ts
+++ b/src/domains/post/schema.ts
@@ -16,12 +16,11 @@ export const GetPostResponseSchema = PostSchema.omit({
   authorId: true,
 }).extend({ isWrittenBySelf: z.boolean() });
 
-export const CreatePostRequestBodySchema = PostSchema.omit({
-  authorId: true,
-  id: true,
-  createdAt: true,
-  expiresAt: true,
-  isDeactivated: true,
+export const CreatePostRequestBodySchema = z.object({
+  title: z.string().max(63),
+  content: z.string().max(255),
+  address: z.string().max(63),
+  addressDetail: z.string().max(63),
 }).merge(MarkerSchema.pick({
   latitude: true,
   longitude: true,

--- a/src/domains/post/schema.ts
+++ b/src/domains/post/schema.ts
@@ -21,6 +21,7 @@ export const CreatePostRequestBodySchema = PostSchema.omit({
   id: true,
   createdAt: true,
   expiresAt: true,
+  isDeactivated: true,
 }).merge(MarkerSchema.pick({
   latitude: true,
   longitude: true,


### PR DESCRIPTION
# 변경점 👍
- 이제 게시글을 생성할 때 제목과 내용의 길이를 제한합니다.
- 게시글을 생성할 때 soft_delete를 위한 필드가 필수 필드로 포함되어 있던 문제점을 해결했습니다.