### PR TITLE
잘못된 onDelete 규칙으로 인해 삭제가 불가능하던 문제점 해결 (ISSUE-94)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,7 +64,7 @@ model Like {
   memberId  Int      @map("member_id")
 
   member Member @relation(fields: [memberId], references: [id])
-  post   Post   @relation(fields: [postId], references: [id])
+  post   Post   @relation(fields: [postId], references: [id], onDelete: Cascade)
 
   @@map("likes")
 }
@@ -75,7 +75,7 @@ model Marker {
   latitude  Float @map("latitude")
   longitude Float @map("longitude")
 
-  post Post @relation(fields: [postId], references: [id])
+  post Post @relation(fields: [postId], references: [id], onDelete: Cascade)
 
   @@map("markers")
 }


### PR DESCRIPTION
# 버그 해결 💊
외래키 참조 시 삭제 규칙이 Restrict로 되어 있어 삭제가 이루어지지 않던 문제점을 해결했습니다.