### PR TITLE
만료된 마커가 조회 가능하던 문제점 해결 및 탈퇴된 회원의 요청에 대한 status code 변경 (ISSUE-100, ISSUE-101)

### DIFF
--- a/src/domains/auth/middleware.ts
+++ b/src/domains/auth/middleware.ts
@@ -54,9 +54,9 @@ export async function authMiddleware(
       sendError(res, '토큰 검증 실패', StatusCodes.UNAUTHORIZED);
       return;
     }
-    
+
     if (member.isDeactivated) {
-      sendError(res, '탈퇴한 사용자의 인증 정보입니다.', StatusCodes.FORBIDDEN);
+      sendError(res, '탈퇴한 사용자의 인증 정보입니다.', StatusCodes.UNAUTHORIZED);
       return;
     }
 

--- a/src/domains/marker/service.ts
+++ b/src/domains/marker/service.ts
@@ -13,6 +13,13 @@ export async function getMarkers(req: AuthenticatedRequest, res: GetMarkersRespo
         }
       }
     },
+    where: {
+      post: {
+        expiresAt: {
+          gt: new Date()
+        },
+      },
+    },
     orderBy: {
       post: {
         createdAt: 'desc',


### PR DESCRIPTION
# 버그 해결 💊
- 만료된 마커도 조회가 가능하던 문제점을 해결했습니다.
- 탈퇴한 회원의 로그인 요청에 대해 forbidden 대신 unauthorized를 전송하도록 변경했습니다.
