### PR TITLE
채팅 서버 개발 (ISSUE-120)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1496,6 +1496,207 @@
           }
         }
       }
+    },
+    "/api/chatrooms": {
+      "get": {
+        "summary": "채팅방 정보 반환",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": true,
+            "description": "Bearer 토큰",
+            "schema": {
+              "type": "string",
+              "example": "Bearer <your-jwt-token>"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "채팅방 정보 반환 성공",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "chatrooms": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer"
+                          },
+                          "peerNickname": {
+                            "type": "string"
+                          },
+                          "post": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer"
+                              },
+                              "iconIdx": {
+                                "type": "integer"
+                              },
+                              "title": {
+                                "type": "string"
+                              },
+                              "content": {
+                                "type": "string"
+                              },
+                              "createdAt": {
+                                "type": "string"
+                              },
+                              "expiresAt": {
+                                "type": "string"
+                              },
+                              "address": {
+                                "type": "string"
+                              },
+                              "isDeactivated": {
+                                "type": "boolean"
+                              },
+                              "likeCount": {
+                                "type": "integer"
+                              },
+                              "viewCount": {
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "iconIdx",
+                              "title",
+                              "content",
+                              "createdAt",
+                              "expiresAt",
+                              "address",
+                              "isDeactivated",
+                              "likeCount",
+                              "viewCount"
+                            ]
+                          },
+                          "lastMessage": {
+                            "type": "object",
+                            "properties": {
+                              "createdAt": {
+                                "type": "string"
+                              },
+                              "content": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "createdAt",
+                              "content"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "peerNickname",
+                          "post",
+                          "lastMessage"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "chatrooms"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "채팅방 생성",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": true,
+            "description": "Bearer 토큰",
+            "schema": {
+              "type": "string",
+              "example": "Bearer <your-jwt-token>"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "postId": {
+                    "type": "integer"
+                  },
+                  "content": {
+                    "type": "string",
+                    "maxLength": 255
+                  }
+                },
+                "required": [
+                  "postId",
+                  "content"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "채팅방 생성 완료",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "receivedChat"
+                    },
+                    "chatroomId": {
+                      "type": "integer"
+                    },
+                    "content": {
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "authorNickname": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "chatroomId",
+                    "content",
+                    "createdAt",
+                    "authorNickname"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -949,6 +949,139 @@ paths:
                     type: string
                 required:
                   - message
+  /api/chatrooms:
+    get:
+      summary: 채팅방 정보 반환
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: header
+          name: Authorization
+          required: true
+          description: Bearer 토큰
+          schema:
+            type: string
+            example: Bearer <your-jwt-token>
+      responses:
+        "200":
+          description: 채팅방 정보 반환 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  chatrooms:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                        peerNickname:
+                          type: string
+                        post:
+                          type: object
+                          properties:
+                            id:
+                              type: integer
+                            iconIdx:
+                              type: integer
+                            title:
+                              type: string
+                            content:
+                              type: string
+                            createdAt:
+                              type: string
+                            expiresAt:
+                              type: string
+                            address:
+                              type: string
+                            isDeactivated:
+                              type: boolean
+                            likeCount:
+                              type: integer
+                            viewCount:
+                              type: integer
+                          required:
+                            - id
+                            - iconIdx
+                            - title
+                            - content
+                            - createdAt
+                            - expiresAt
+                            - address
+                            - isDeactivated
+                            - likeCount
+                            - viewCount
+                        lastMessage:
+                          type: object
+                          properties:
+                            createdAt:
+                              type: string
+                            content:
+                              type: string
+                          required:
+                            - createdAt
+                            - content
+                      required:
+                        - id
+                        - peerNickname
+                        - post
+                        - lastMessage
+                required:
+                  - chatrooms
+    post:
+      summary: 채팅방 생성
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: header
+          name: Authorization
+          required: true
+          description: Bearer 토큰
+          schema:
+            type: string
+            example: Bearer <your-jwt-token>
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                postId:
+                  type: integer
+                content:
+                  type: string
+                  maxLength: 255
+              required:
+                - postId
+                - content
+      responses:
+        "200":
+          description: 채팅방 생성 완료
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    const: receivedChat
+                  chatroomId:
+                    type: integer
+                  content:
+                    type: string
+                  createdAt:
+                    type: string
+                  authorNickname:
+                    type: string
+                required:
+                  - type
+                  - chatroomId
+                  - content
+                  - createdAt
+                  - authorNickname
 components:
   securitySchemes:
     bearerAuth:

--- a/examples/chat/index.html
+++ b/examples/chat/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>채팅 클라이언트</title>
+  <style>
+    body { font-family: sans-serif; padding: 20px; }
+    #log { white-space: pre-wrap; border: 1px solid #ccc; padding: 10px; height: 300px; overflow-y: auto; margin-bottom: 10px; }
+    #inputArea { display: flex; gap: 10px; }
+    #inputArea input, #inputArea button { font-size: 1rem; }
+  </style>
+</head>
+<body>
+
+<h1>WebSocket 채팅 클라이언트</h1>
+
+<label>
+  토큰:
+  <input id="token" placeholder="JWT Token" style="width: 400px">
+</label>
+<button onclick="connect()">서버 연결</button>
+
+<div id="log"></div>
+
+<div id="inputArea">
+  <input id="chatroomId" type="number" placeholder="채팅방 ID">
+  <input id="message" placeholder="보낼 메시지">
+  <button onclick="sendMessage()">전송</button>
+</div>
+
+<script>
+  let socket;
+
+  function log(msg) {
+    const el = document.getElementById('log');
+    el.textContent += msg + '\n';
+    el.scrollTop = el.scrollHeight;
+  }
+
+  function connect() {
+    const token = document.getElementById('token').value.trim();
+    if (!token) return alert("토큰을 입력하세요.");
+
+    socket = new WebSocket(`ws://localhost:3000?token=${token}`);
+
+    socket.addEventListener('open', () => log('✅ 서버에 연결됨'));
+    socket.addEventListener('message', (event) => {
+      const data = JSON.parse(event.data);
+      if (data.type === 'receivedChat') {
+        log(`💬 [받음] 채팅방 ${data.chatroomId} → ${data.content}`);
+      } else if (data.type === 'unreadChats') {
+        data.chats.forEach(chat => {
+          log(`📨 [안읽음] 채팅방 ${chat.chatroomId} → ${chat.content}`);
+        });
+      } else if (data.type === 'error') {
+        log(`❌ 오류: ${data.message}`);
+      }
+    });
+    socket.addEventListener('close', () => log('🔌 연결 종료됨'));
+    socket.addEventListener('error', (e) => log('⚠ 연결 오류: ' + e.message));
+  }
+
+  function sendMessage() {
+    if (!socket || socket.readyState !== WebSocket.OPEN) {
+      return alert('서버에 연결되어 있지 않습니다.');
+    }
+    const chatroomId = parseInt(document.getElementById('chatroomId').value, 10);
+    const content = document.getElementById('message').value.trim();
+    if (!chatroomId || !content) return alert("채팅방 ID와 메시지를 모두 입력하세요.");
+
+    const payload = {
+      type: 'sentChat',
+      chatroomId,
+      content,
+    };
+    socket.send(JSON.stringify(payload));
+    document.getElementById('message').value = '';
+  }
+</script>
+
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@types/morgan": "^1.9.9",
     "@types/node": "^22.15.3",
     "@types/swagger-ui-express": "^4.1.8",
+    "@types/ws": "^8.18.1",
     "cross-env": "^7.0.3",
     "dotenv-cli": "^8.0.0",
     "eslint": "^9.26.0",
@@ -65,6 +66,7 @@
     "morgan": "^1.10.0",
     "rotating-file-stream": "^3.2.6",
     "swagger-ui-express": "^5.0.1",
+    "ws": "^8.18.2",
     "zod": "^3.24.4",
     "zod-prisma-types": "^3.2.4"
   },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dev": "cross-env NODE_ENV=development nodemon -e ts,js,.env --exec \"tsx watch src/index.ts\"",
     "gen:openapi": "pnpm db:generate && tsx scripts/openapi/index.ts",
     "gen:env": "tsx scripts/env/encode.ts",
+    "gen:jwt": "tsx scripts/jwt/index.ts",
     "seed:posts": "cross-env NODE_ENV=staging tsx scripts/mock/createPost.ts",
     "prepare": "husky"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       swagger-ui-express:
         specifier: ^5.0.1
         version: 5.0.1(express@5.1.0)
+      ws:
+        specifier: ^8.18.2
+        version: 8.18.2
       zod:
         specifier: ^3.24.4
         version: 3.24.4
@@ -81,6 +84,9 @@ importers:
       '@types/swagger-ui-express':
         specifier: ^4.1.8
         version: 4.1.8
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -853,6 +859,9 @@ packages:
 
   '@types/swagger-ui-express@4.1.8':
     resolution: {integrity: sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.31.1':
     resolution: {integrity: sha512-oUlH4h1ABavI4F0Xnl8/fOtML/eu8nI2A1nYd+f+55XI0BLu+RIqKoCiZKNo6DtqZBEQm5aNKA20G3Z5w3R6GQ==}
@@ -2128,6 +2137,18 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  ws@8.18.2:
+    resolution: {integrity: sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   yaml@2.7.1:
     resolution: {integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==}
     engines: {node: '>= 14'}
@@ -3187,6 +3208,10 @@ snapshots:
     dependencies:
       '@types/express': 5.0.1
       '@types/serve-static': 1.15.7
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.15.3
 
   '@typescript-eslint/eslint-plugin@8.31.1(@typescript-eslint/parser@8.31.1(eslint@9.26.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.26.0(jiti@1.21.7))(typescript@5.8.3)':
     dependencies:
@@ -4519,6 +4544,8 @@ snapshots:
   word-wrap@1.2.5: {}
 
   wrappy@1.0.2: {}
+
+  ws@8.18.2: {}
 
   yaml@2.7.1: {}
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -109,11 +109,14 @@ model Chat {
   receiverId Int      @map("receiver_id")
   isRead     Boolean  @map("is_read")
   createdAt  DateTime @default(now()) @map("created_at")
+  content    String   @db.Text()
 
   chatroom ChatRoom @relation(fields: [chatroomId], references: [id])
   sender   Member   @relation("SentChats", fields: [senderId], references: [id])
   receiver Member   @relation("ReceivedChats", fields: [receiverId], references: [id])
 
+  @@index(chatroomId)
+  @@index(createdAt)
   @@map("chats")
 }
 

--- a/scripts/jwt/index.ts
+++ b/scripts/jwt/index.ts
@@ -1,0 +1,42 @@
+import jwt from 'jsonwebtoken';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+// CLI 인자 파싱
+const args = process.argv.slice(2);
+const getArg = (key: string): string | undefined => {
+  const index = args.indexOf(key);
+  return index !== -1 && args[index + 1] ? args[index + 1] : undefined;
+};
+
+const id = getArg('--id');
+const email = getArg('--email');
+const name = getArg('--name');
+const t = getArg('-t') ?? '3600';
+
+if (!id || !email || !name) {
+  console.error('Usage: tsx generateExpiredJwt.ts --id <id> --email <email> --name <name> [-t <secondsAgo>]');
+  process.exit(1);
+}
+
+const offsetSeconds = parseInt(t, 10);
+if (isNaN(offsetSeconds)) {
+  console.error('-t 값은 숫자여야 합니다.');
+  process.exit(1);
+}
+
+const expiredAt = Math.floor(Date.now() / 1000) + offsetSeconds;
+
+const payload = {
+  id: parseInt(id, 10),
+  email,
+  name,
+  exp: expiredAt,
+};
+
+const token = jwt.sign(payload, process.env.JWT_SECRET as string, {
+  algorithm: 'HS256',
+});
+
+console.log('JWT Generated\n\n', token);

--- a/scripts/openapi/chats/index.ts
+++ b/scripts/openapi/chats/index.ts
@@ -1,0 +1,49 @@
+import { currentApiPrefix } from '../../../src/constants';
+import { tokenHeader } from '../headers';
+import {
+  CreateChatroomRequestBodySchema,
+  CreateChatroomResponseSchema, GetChatroomsResponseBodySchema,
+} from '../../../src/domains/chat/schema';
+
+export const chatApiPaths = {
+  [`${currentApiPrefix}/chatrooms`]: {
+    get: {
+      summary: '채팅방 정보 반환',
+      security: [{ bearerAuth: [] }],
+      parameters: [tokenHeader],
+      responses: {
+        200: {
+          description: '채팅방 정보 반환 성공',
+          content: {
+            'application/json': {
+              schema: GetChatroomsResponseBodySchema,
+            }
+          }
+        }
+      }
+    },
+    post: {
+      summary: '채팅방 생성',
+      security: [{ bearerAuth: [] }],
+      parameters: [tokenHeader],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: CreateChatroomRequestBodySchema,
+          },
+        },
+      },
+      responses: {
+        200: {
+          description: '채팅방 생성 완료',
+          content: {
+            'application/json': {
+              schema: CreateChatroomResponseSchema,
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/scripts/openapi/index.ts
+++ b/scripts/openapi/index.ts
@@ -10,6 +10,7 @@ import { postApiPaths } from './post';
 import { reportApiPaths } from './report';
 import { likeApiPaths } from './like';
 import { notificationApiPaths } from './notification';
+import { chatApiPaths } from './chats';
 
 export const openApiDocument = createDocument({
   openapi: '3.1.0',
@@ -47,6 +48,7 @@ export const openApiDocument = createDocument({
     ...reportApiPaths,
     ...likeApiPaths,
     ...notificationApiPaths,
+    ...chatApiPaths,
   },
 });
 

--- a/src/domains/auth/middleware.ts
+++ b/src/domains/auth/middleware.ts
@@ -2,10 +2,9 @@ import {
   AuthenticatedRequest,
 } from '@/domains/auth/types';
 import { NextFunction, Response } from 'express';
-import { verifyToken } from '@/domains/auth/utils';
+import { isInvalidatedToken, verifyToken } from '@/domains/auth/utils';
 import prisma from '@/utils/database';
 import rateLimit from 'express-rate-limit';
-import redis from '@/utils/redis';
 import { UnauthorizedError } from '@/domains/error/HttpError';
 
 const oneDayInMs = 24 * 60 * 60 * 1000;
@@ -41,7 +40,7 @@ export async function authMiddleware(
 
   const decoded = verifyToken(token);
 
-  if(await redis.exists(`access_token:${token}`)) {
+  if(await isInvalidatedToken(token)) {
     throw new UnauthorizedError('토큰이 필요합니다.');
   }
 

--- a/src/domains/auth/utils.ts
+++ b/src/domains/auth/utils.ts
@@ -5,6 +5,7 @@ import { AuthenticatedJWTPayload } from '@/domains/auth/types';
 import { sendEmail } from '@/utils/email';
 import '@/utils/config';
 import prisma from '@/utils/database';
+import redis from '@/utils/redis';
 
 const JWT_SECRET = process.env.JWT_SECRET as string;
 const PASSWORD_SECRET = process.env.PASSWORD_SECRET as string;
@@ -48,6 +49,10 @@ export function generateToken(member: Member) {
 
 export function verifyToken(token: string) {
   return jwt.verify(token, JWT_SECRET) as AuthenticatedJWTPayload;
+}
+
+export async function isInvalidatedToken(token: string) {
+  return redis.exists(`access_token:${token}`);
 }
 
 export function hashPassword(password: string) {

--- a/src/domains/chat/ChatClient.ts
+++ b/src/domains/chat/ChatClient.ts
@@ -58,7 +58,7 @@ export default class ChatClient {
       content,
     };
     // redis publish
-    pub.publish(`${REDIS_CHANNEL_PREFIX}${receiverId}`, JSON.stringify(publishable));
+    pub.publish(`${REDIS_CHANNEL_PREFIX}${chatroomId}:${receiverId}`, JSON.stringify(publishable));
   }
 
 

--- a/src/domains/chat/ChatClient.ts
+++ b/src/domains/chat/ChatClient.ts
@@ -1,0 +1,157 @@
+import WebSocket from 'ws';
+import {
+  InboundChat,
+  OutboundChat, PublishableChat, ReadChatroomMessage,
+  SocketMessage,
+} from '@/domains/chat/types';
+import {
+  InboundChatSchema,
+  ReadChatroomMessageSchema,
+} from '@/domains/chat/schema';
+import ChatServer, { REDIS_CHANNEL_PREFIX } from '@/domains/chat/ChatServer';
+import prisma from '@/utils/database';
+import { pub } from '@/utils/redis';
+import {
+  findUnreadChats,
+  getJoinedChatroomWithId,
+} from '@/domains/chat/service';
+
+export default class ChatClient {
+  private readonly ws: WebSocket;
+  public isAlive = false;
+  private readonly _memberId: number;
+  private readonly server: ChatServer;
+  private pingInterval: NodeJS.Timeout | null = null;
+  constructor(server: ChatServer, ws: WebSocket, memberId: number) {
+    this.server = server;
+    this.ws = ws;
+    this.isAlive = true;
+    this._memberId = memberId;
+    this.bindEventListeners();
+    this.startPingChecker();
+    this.sendUnreadChats();
+  }
+
+  async sendUnreadChats() {
+    const chats = await findUnreadChats(this.memberId);
+    this.send({ chats, type: 'unreadChats' });
+  }
+
+  async handleInboundChat(payload: InboundChat) {
+    const { chatroomId, content } = InboundChatSchema.parse(payload);
+    // 채팅을 보낸 사용자가 참여한 채팅방 조회.
+    const chatroom = await getJoinedChatroomWithId(this.memberId, chatroomId);
+    if(! chatroom) {
+      this.sendError('참여 중인 채팅방이 아닙니다.');
+      return;
+    }
+    // sender가 아닌 사용자가 receiver
+    const receiverId = chatroom.requesterId === this.memberId ? chatroom.authorId : chatroom.requesterId;
+    const senderNickname = chatroom.requesterId
+    === this.memberId ? chatroom.authorNickname : chatroom.requesterNickname;
+    const publishable: PublishableChat = {
+      type: 'publish',
+      createdAt: new Date(),
+      senderId: this.memberId,
+      senderNickname,
+      chatroomId,
+      content,
+    };
+    // redis publish
+    pub.publish(`${REDIS_CHANNEL_PREFIX}${receiverId}`, JSON.stringify(publishable));
+  }
+
+
+  async handleChatroomRead(payload: ReadChatroomMessage) {
+    const { chatroomId } = ReadChatroomMessageSchema.parse(payload);
+    await prisma.chat.updateMany({
+      where: {
+        chatroomId,
+        receiverId: this.memberId,
+      },
+      data: {
+        isRead: true,
+      }
+    });
+  }
+
+  bindEventListeners() {
+    this.ws.on('message', async(message) => {
+      try {
+        const payload = JSON.parse(message.toString()) as SocketMessage;
+        switch(payload.type) {
+          case 'sentChat':
+            await this.handleInboundChat(payload);
+            break;
+          case 'read':
+            await this.handleChatroomRead(payload);
+            break;
+        }
+      } catch(e) {
+        console.error(e);
+        this.sendError('잘못된 메시지 형식입니다.');
+      }
+    });
+    this.ws.on('pong', () => {
+      this.isAlive = true;
+    });
+    this.ws.on('close', this.close.bind(this));
+  }
+
+  sendChat(payload: Omit<OutboundChat, 'type'>) {
+    return this.send({
+      type: 'receivedChat',
+      ...payload,
+    });
+  }
+
+  sendError(message: string) {
+    this.send({
+      type: 'error',
+      message,
+    });
+  }
+
+  send(payload: SocketMessage) {
+    if (!this.isAlive || this.ws.readyState !== WebSocket.OPEN) {
+      console.warn(`메시지 전송 실패: 소켓 연결 종료 상태 (memberId=${this.memberId})`);
+      return;
+    }
+    return this.ws.send(JSON.stringify(payload));
+  }
+
+  startPingChecker() {
+    this.pingInterval = setInterval(() => {
+      if (this.ws.readyState !== WebSocket.OPEN) return;
+
+      if (!this.isAlive) {
+        console.log(`ping timeout: closing member ${this.memberId}`);
+        this.close();
+        return;
+      }
+
+      this.isAlive = false;
+      try {
+        this.ws.ping();
+      } catch (e) {
+        console.error(`ping error: member ${this.memberId}`, e);
+        this.close();
+      }
+    }, 30000);
+  }
+
+  get memberId() {
+    return this._memberId;
+  }
+
+  close() {
+    if (this.pingInterval) {
+      clearInterval(this.pingInterval);
+    }
+    if(this.ws.readyState === WebSocket.OPEN) {
+      this.ws.close();
+    }
+    this.isAlive = false;
+    this.server.removeClient(this);
+  }
+}

--- a/src/domains/chat/ChatServer.ts
+++ b/src/domains/chat/ChatServer.ts
@@ -1,0 +1,128 @@
+import http, { IncomingMessage } from 'node:http';
+import WebSocket, { WebSocketServer } from 'ws';
+import { isInvalidatedToken, verifyToken } from '@/domains/auth/utils';
+import ChatClient from '@/domains/chat/ChatClient';
+import { pub, sub } from '@/utils/redis';
+import { PublishableChatSchema } from '@/domains/chat/schema';
+import prisma from '@/utils/database';
+import { sendPushToMember } from '@/domains/notification/utils';
+import { PublishableChat } from '@/domains/chat/types';
+
+export const REDIS_CHANNEL_PREFIX = 'chatroom:';
+export default class ChatServer {
+
+  private readonly wss: WebSocketServer;
+  private static instance: ChatServer;
+  private clients: Map<number, ChatClient> = new Map();
+
+  constructor(http: http.Server) {
+    this.wss = new WebSocketServer({ server: http });
+    ChatServer.instance = this;
+    this.bindConnectionHandler();
+    this.bindPubSubHandler();
+  }
+  async handleSocketConnection(ws: WebSocket, req: IncomingMessage) {
+    try {
+      const url = req.url!;
+      const token = url.split('?token=')[1];
+      const { id: memberId } = verifyToken(token);
+      if(await isInvalidatedToken(token)) {
+        this.sendErrorAndClose(ws, '사용자 인증 정보가 유효하지 않습니다.');
+        return;
+      }
+      // client 등록
+      const client = new ChatClient(this, ws, memberId);
+      this.registerClient(client);
+    } catch(e) {
+      this.sendErrorAndClose(ws, '서버 연결 중 에러가 발생했습니다.');
+      console.error(e);
+    }
+  }
+  // send chat to another client or publish push message
+  // handle redis publish/subscribed message
+  sendErrorAndClose(ws: WebSocket, message: string) {
+    if (ws.readyState === WebSocket.OPEN) {
+      const payload = JSON.stringify({
+        type: 'error',
+        message,
+      });
+      ws.send(payload);
+    }
+    ws.close(4000, message);
+  }
+
+  async sendOrNotificate(payload: PublishableChat, receiverId: number) {
+    // 온/오프라인 체크 후 메시지 전송 방식 결정
+    const {
+      content,
+      createdAt,
+      chatroomId,
+      senderId,
+      senderNickname,
+    } = PublishableChatSchema.parse(payload);
+    let isRead = false;
+    if(this.clients.has(receiverId)) {
+      isRead = true;
+      this.clients.get(receiverId)!.sendChat({
+        chatroomId,
+        createdAt,
+        content,
+      });
+    } else {
+      await this.sendChatNotification(receiverId, senderNickname, content);
+    }
+    await prisma.chat.create({
+      data: {
+        chatroomId,
+        content,
+        senderId,
+        receiverId,
+        isRead, // 현재 전송 가능한 경우 true
+        createdAt,
+      }
+    });
+  }
+
+  async handleMessagePublish(_: string, channel: string, message: string) {
+    // 누군가 메시지 publish
+    try {
+      const receiverId = parseInt(channel.split(':')[1]);
+      const payload = JSON.parse(message);
+      await this.sendOrNotificate(payload, receiverId);
+    } catch(e) {
+      console.error(e);
+    }
+  }
+
+  async sendChatNotification(receiverId: number, senderNickname: string, content: string) {
+    const receiver = await prisma.member.findUniqueOrThrow({
+      where: { id: receiverId },
+    });
+    return sendPushToMember(receiver, senderNickname, content);
+  };
+
+  bindPubSubHandler() {
+    sub.psubscribe(`${REDIS_CHANNEL_PREFIX}*`, (err) => {
+      if(err) {
+        console.error(err);
+      }
+    });
+    pub.on('pmessage', this.handleMessagePublish.bind(this));
+  }
+
+  bindConnectionHandler() {
+    this.wss.on('connection', this.handleSocketConnection.bind(this));
+  }
+
+  registerClient(client: ChatClient) {
+    this.clients.set(client.memberId, client);
+  }
+
+  removeClient(client: ChatClient) { // 단순히 map에서 제거. ws close는 클라이언트에서 처리
+    this.clients.delete(client.memberId);
+  }
+
+  static getInstance() {
+    return ChatServer.instance;
+  }
+}

--- a/src/domains/chat/ChatServer.ts
+++ b/src/domains/chat/ChatServer.ts
@@ -51,8 +51,8 @@ export default class ChatServer {
     ws.close(4000, message);
   }
 
-  async sendOrNotificate(payload: PublishableChat, receiverId: number) {
-    // 온/오프라인 체크 후 메시지 전송 방식 결정
+  async createChat(payload: PublishableChat, receiverId: number) {
+    // 온/오프라인 체크 후 메시지 전송 방식 결정, 추후 db 쿼리와 전송 로직 분리
     const {
       content,
       createdAt,
@@ -86,9 +86,9 @@ export default class ChatServer {
   async handleMessagePublish(_: string, channel: string, message: string) {
     // 누군가 메시지 publish
     try {
-      const receiverId = parseInt(channel.split(':')[1]);
+      const receiverId = parseInt(channel.split(':')[2]);
       const payload = JSON.parse(message);
-      await this.sendOrNotificate(payload, receiverId);
+      await this.createChat(payload, receiverId);
     } catch(e) {
       console.error(e);
     }

--- a/src/domains/chat/controller.ts
+++ b/src/domains/chat/controller.ts
@@ -1,0 +1,10 @@
+import express from 'express';
+import { authMiddleware } from '@/domains/auth/middleware';
+import { createChatroom, getChatrooms } from '@/domains/chat/service';
+
+const chatController = express.Router();
+
+chatController.post('/chatrooms', authMiddleware, createChatroom);
+chatController.get('/chatrooms', authMiddleware, getChatrooms);
+
+export default chatController;

--- a/src/domains/chat/schema.ts
+++ b/src/domains/chat/schema.ts
@@ -1,0 +1,84 @@
+import { z } from 'zod';
+import { ChatRoomSchema, ChatSchema, PostSchema } from '@/schemas';
+
+export const MessageType = z.enum(['sentChat', 'receivedChat', 'read', 'error', 'publish', 'unreadChats']);
+
+export const ErrorMessageSchema = z.object({
+  type: z.literal(MessageType.enum.error),
+  message: z.string(),
+});
+
+export const InboundChatSchema = z.object({
+  type: z.literal(MessageType.enum.sentChat),
+}).merge(
+  ChatSchema.pick({
+    chatroomId: true,
+    content: true,
+  })
+).extend({
+  content: z.string().max(255),
+});
+
+export const OutboundChatSchema = z.object({
+  type: z.literal(MessageType.enum.receivedChat),
+}).merge(
+  ChatSchema.pick({
+    chatroomId: true,
+    content: true,
+    createdAt: true,
+  })
+);
+
+export const UnreadChatsSchema = z.object({
+  type: z.literal(MessageType.enum.unreadChats),
+  chats: z.array(OutboundChatSchema),
+});
+
+export const PublishableChatSchema = OutboundChatSchema.extend({
+  type: z.literal(MessageType.enum.publish),
+  senderId: z.number(),
+  senderNickname: z.string(),
+});
+
+export const ReadChatroomMessageSchema = z.object({
+  type: z.literal(MessageType.enum.read),
+}).merge(
+  ChatSchema.pick({
+    chatroomId: true,
+  })
+);
+
+export const SocketMessageSchema = z.union([
+  InboundChatSchema,
+  OutboundChatSchema,
+  PublishableChatSchema,
+  ReadChatroomMessageSchema,
+  ErrorMessageSchema,
+  UnreadChatsSchema,
+]);
+
+export const CreateChatroomRequestBodySchema = z.object({
+  postId: PostSchema.shape.id,
+  content: InboundChatSchema.shape.content,
+});
+
+export const CreateChatroomResponseSchema = OutboundChatSchema.merge(
+  ChatRoomSchema.pick({
+    authorNickname: true,
+  })
+);
+
+export const GetChatroomsResponseBodySchema = z.object({
+  chatrooms: z.array(ChatRoomSchema.pick({
+    id: true,
+  }).extend({
+    peerNickname: z.string(),
+    post: PostSchema.omit({
+      authorId: true,
+    }),
+    lastMessage: ChatSchema.pick({
+      createdAt: true,
+      content: true,
+    }),
+  }))
+});

--- a/src/domains/chat/service.ts
+++ b/src/domains/chat/service.ts
@@ -41,6 +41,9 @@ export async function getChatrooms(req: AuthenticatedRequest, res: GetChatroomsR
       chats: {
         take: 1,
         orderBy: { createdAt: 'desc' },
+        omit: {
+          senderId: true,
+        }
       }
     },
   });

--- a/src/domains/chat/service.ts
+++ b/src/domains/chat/service.ts
@@ -1,0 +1,170 @@
+import {
+  CreateChatroomRequest,
+  CreateChatroomResponse,
+  GetChatroomsResponse,
+  OutboundChat,
+  PublishableChat,
+} from '@/domains/chat/types';
+import {
+  CreateChatroomRequestBodySchema,
+} from '@/domains/chat/schema';
+import prisma from '@/utils/database';
+import { BadRequestError, NotFoundError } from '@/domains/error/HttpError';
+import {
+  createAuthorNickname,
+  createRequesterNickname,
+} from '@/domains/chat/utils';
+import ChatServer from '@/domains/chat/ChatServer';
+import { StatusCodes } from 'http-status-codes';
+import { ChatRoom } from '@/schemas';
+import { InternalMember, PublicMember } from '@/domains/member/types';
+import { Prisma } from '.prisma/client';
+import { AuthenticatedRequest } from '@/domains/auth/types';
+
+export async function getChatrooms(req: AuthenticatedRequest, res: GetChatroomsResponse) {
+  const member = req.member!;
+  const chatrooms = await prisma.chatRoom.findMany({
+    where: {
+      OR: [{ authorId: member.id }, { requesterId: member.id }],
+    },
+    select: {
+      authorId: true,
+      requesterId: true,
+      authorNickname: true,
+      requesterNickname: true,
+      id: true,
+      post: {
+        omit: {
+          authorId: true,
+        }
+      },
+      chats: {
+        take: 1,
+        orderBy: { createdAt: 'desc' },
+      }
+    },
+  });
+  const chatroomInfo = chatrooms.map(chatroom => ({
+    id: chatroom.id,
+    peerNickname: chatroom.authorId === member.id ? chatroom.requesterNickname : chatroom.authorNickname,
+    post: chatroom.post,
+    lastMessage: chatroom.chats[0],
+  }));
+  res.status(StatusCodes.OK).json({
+    chatrooms: chatroomInfo,
+  });
+}
+
+export async function createChatroom(req: CreateChatroomRequest, res: CreateChatroomResponse) {
+  const member = req.member!;
+  const { postId, content } = CreateChatroomRequestBodySchema.parse(req.body);
+  const chatroom = await prisma.chatRoom.findFirst({
+    where: {
+      postId,
+      requesterId: member.id,
+    }
+  });
+  const post = await prisma.post.findUnique({
+    where: {
+      id: postId,
+    }
+  });
+
+  if(! post) {
+    throw new NotFoundError('존재하지 않는 게시글입니다.');
+  }
+  if(chatroom) {
+    const chat = createPublishableChat(chatroom, member, content);
+    await ChatServer.getInstance().sendOrNotificate(chat, post.authorId);
+    const outboundChat = createOutboundChat(chat, chatroom);
+    res.status(StatusCodes.OK).json({
+      ...outboundChat,
+      authorNickname: chatroom.authorNickname,
+    });
+    return;
+  }
+
+  if(post.authorId === member.id) {
+    throw new BadRequestError('자기 자신과의 채팅방은 만들 수 없습니다.');
+  }
+
+  const createdChatroom = await prisma.chatRoom.create({
+    data: {
+      postId: post.id,
+      authorId: post.authorId,
+      requesterId: member.id,
+      requesterNickname: createRequesterNickname(),
+      authorNickname: createAuthorNickname(),
+    }
+  });
+  const publishableChat = createPublishableChat(createdChatroom, member, content);
+  const outboundChat = createOutboundChat(publishableChat, createdChatroom);
+  await ChatServer.getInstance().sendOrNotificate(publishableChat, post.authorId);
+  res.status(StatusCodes.OK).json({
+    ...outboundChat,
+    authorNickname: createdChatroom.authorNickname,
+  });
+}
+
+export async function findUnreadChats(member: PublicMember | number, chatroomId?: number) {
+  if(typeof member === 'object') {
+    member = member.id;
+  }
+  return (await prisma.chat.findMany({
+    where: {
+      receiverId: member,
+      isRead: false,
+      ...(chatroomId && { chatroomId }),
+    },
+    select: {
+      chatroomId: true,
+      content: true,
+      createdAt: true,
+    },
+    orderBy: { createdAt: 'desc' },
+  })).map((chat) => ({
+    ...chat,
+    type: 'receivedChat',
+  } as OutboundChat));
+}
+
+export async function getJoinedChatroomWithId(member: PublicMember | number, chatroomId: number) {
+  return getJoinedChatroom(member, {
+    id: chatroomId,
+  });
+}
+
+export async function getJoinedChatroom(member: PublicMember | number,
+                                        where?: Prisma.ChatRoomWhereInput,
+                                        select?: Prisma.ChatRoomSelect) {
+  const id = typeof member === 'number' ? member : member.id;
+  return prisma.chatRoom.findFirst({
+    where: {
+      OR: [{ requesterId: id }, { authorId: id }],
+      ...where
+    },
+    select,
+  });
+}
+
+
+export function createOutboundChat(chat: PublishableChat, chatroom: ChatRoom): OutboundChat {
+  return {
+    createdAt: chat.createdAt,
+    type: 'receivedChat',
+    content: chat.content,
+    chatroomId: chatroom.id,
+  };
+}
+
+export function createPublishableChat(
+  chatroom: ChatRoom, member: InternalMember, content: string): PublishableChat {
+  return {
+    createdAt: new Date(),
+    content,
+    chatroomId: chatroom.id,
+    senderId: member.id,
+    senderNickname: chatroom.requesterNickname,
+    type: 'publish'
+  };
+}

--- a/src/domains/chat/service.ts
+++ b/src/domains/chat/service.ts
@@ -75,7 +75,7 @@ export async function createChatroom(req: CreateChatroomRequest, res: CreateChat
   }
   if(chatroom) {
     const chat = createPublishableChat(chatroom, member, content);
-    await ChatServer.getInstance().sendOrNotificate(chat, post.authorId);
+    await ChatServer.getInstance().createChat(chat, post.authorId);
     const outboundChat = createOutboundChat(chat, chatroom);
     res.status(StatusCodes.OK).json({
       ...outboundChat,
@@ -99,7 +99,7 @@ export async function createChatroom(req: CreateChatroomRequest, res: CreateChat
   });
   const publishableChat = createPublishableChat(createdChatroom, member, content);
   const outboundChat = createOutboundChat(publishableChat, createdChatroom);
-  await ChatServer.getInstance().sendOrNotificate(publishableChat, post.authorId);
+  await ChatServer.getInstance().createChat(publishableChat, post.authorId);
   res.status(StatusCodes.OK).json({
     ...outboundChat,
     authorNickname: createdChatroom.authorNickname,

--- a/src/domains/chat/types.d.ts
+++ b/src/domains/chat/types.d.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+import {
+  InboundChatSchema,
+  ReadChatroomMessageSchema,
+  SocketMessageSchema,
+  OutboundChatSchema,
+  ErrorMessageSchema,
+  PublishableChatSchema,
+  UnreadChatsSchema,
+  CreateChatroomRequestBodySchema,
+  CreateChatroomResponseSchema,
+  GetChatroomsResponseBodySchema,
+} from '@/domains/chat/schema';
+import { AuthenticatedRequest } from '@/domains/auth/types';
+import { Response } from 'express';
+
+export type SocketMessage = z.infer<typeof SocketMessageSchema>;
+export type InboundChat = z.infer<typeof InboundChatSchema>;
+export type OutboundChat = z.infer<typeof OutboundChatSchema>;
+export type PublishableChat = z.infer<typeof PublishableChatSchema>;
+export type ReadChatroomMessage = z.infer<typeof ReadChatroomMessageSchema>;
+
+
+export type ErrorMessage = z.infer<typeof ErrorMessageSchema>;
+
+export type CreateChatroomRequest = AuthenticatedRequest<{}, z.infer<typeof CreateChatroomRequestBodySchema>>;
+export type CreateChatroomResponse = Response<z.infer<typeof CreateChatroomResponseSchema>>;
+export type GetChatroomsResponse = Response<z.infer<typeof GetChatroomsResponseBodySchema>>;
+
+export type UnreadChats = z.infer<typeof UnreadChatsSchema>;

--- a/src/domains/chat/utils.ts
+++ b/src/domains/chat/utils.ts
@@ -1,0 +1,13 @@
+export function createAuthorNickname(): string {
+  return `반짝이 관측자 ${generateRandomDigits(4)}`;
+}
+
+export function createRequesterNickname(): string {
+  return `반짝이 ${generateRandomDigits(4)}`;
+}
+
+function generateRandomDigits(length: number): string {
+  return Math.floor(Math.random() * Math.pow(10, length))
+  .toString()
+  .padStart(length, '0');
+}

--- a/src/domains/notification/service.ts
+++ b/src/domains/notification/service.ts
@@ -7,7 +7,7 @@ import {
   LocationInputRequestBodySchema,
 } from '@/domains/notification/schema';
 import { Response } from 'express';
-import { sendPushMessage } from '@/domains/notification/utils';
+import { sendPushToMember } from '@/domains/notification/utils';
 import { getNearbyMarkerCount } from '@/domains/marker/service';
 import { StatusCodes } from 'http-status-codes';
 import prisma from '@/utils/database';
@@ -18,7 +18,7 @@ export async function handleLocationInput(req: LocationInputRequest, res: Respon
   if(postCount === 0) {
     return;
   }
-  await sendPushMessage(req.member!, `주변에 ${postCount}개 반짝이가 올라왔어요!`, '반짝이 앱을 통해 확인해봐요');
+  await sendPushToMember(req.member!, `주변에 ${postCount}개 반짝이가 올라왔어요!`, '반짝이 앱을 통해 확인해봐요');
   res.status(StatusCodes.OK).send();
 }
 

--- a/src/domains/notification/types.d.ts
+++ b/src/domains/notification/types.d.ts
@@ -5,5 +5,5 @@ import {
 } from '@/domains/notification/schema';
 import { z } from 'zod';
 
-export type LocationInputRequest = AuthenticatedRequest<z.infer<typeof LocationInputRequestBodySchema>>;
-export type ExpoTokenInputRequest = AuthenticatedRequest<z.infer<typeof ExpoTokenInputRequestBodySchema>>;
+export type LocationInputRequest = AuthenticatedRequest<{}, z.infer<typeof LocationInputRequestBodySchema>>;
+export type ExpoTokenInputRequest = AuthenticatedRequest<{}, z.infer<typeof ExpoTokenInputRequestBodySchema>>;

--- a/src/domains/notification/utils.ts
+++ b/src/domains/notification/utils.ts
@@ -6,7 +6,18 @@ const expo = new Expo({
   accessToken: process.env.EXPO_ACCESS_TOKEN,
 });
 
-export async function sendPushMessage(member: InternalMember, title: string, body: string) {
+export async function sendPushMessage(token: string, title: string, body: string) {
+  const message: ExpoPushMessage = {
+    to: token,
+    sound: 'default',
+    title,
+    body,
+  };
+  const [result] = await expo.sendPushNotificationsAsync([message]);
+  return result;
+}
+
+export async function sendPushToMember(member: InternalMember, title: string, body: string) {
   const { expoToken: token } = member;
   if(! Expo.isExpoPushToken(token)) {
     console.error(`Invalid push token for member id ${member.id}`);
@@ -23,13 +34,5 @@ export async function sendPushMessage(member: InternalMember, title: string, bod
       status: 'error',
     };
   }
-
-  const message: ExpoPushMessage = {
-    to: token,
-    sound: 'default',
-    title,
-    body,
-  };
-  const [result] = await expo.sendPushNotificationsAsync([message]);
-  return result;
+  return sendPushMessage(token, title, body);
 }

--- a/src/domains/report/types.d.ts
+++ b/src/domains/report/types.d.ts
@@ -1,4 +1,4 @@
 import { AuthenticatedRequest } from '@/domains/auth/types';
 import { CreateReportRequestBodySchema } from '@/domains/report/schema';
 
-export type CreateReportRequest = AuthenticatedRequest<z.infer<typeof CreateReportRequestBodySchema>>;
+export type CreateReportRequest = AuthenticatedRequest<{}, z.infer<typeof CreateReportRequestBodySchema>>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import logger from '@/utils/logger';
 import swaggerUi from 'swagger-ui-express';
 import { getMarkdownHtml } from '@/utils/docs';
 import { pathToFileURL } from 'node:url';
+import * as http from 'node:http';
 
 export async function start() {
   const app = express();
@@ -21,7 +22,9 @@ export async function start() {
   // privacy policy, tos, api docs
   await registerDocumentRoutes(app);
 
-  app.listen(PORT, () => {
+  const httpServer = http.createServer(app);
+
+  httpServer.listen(PORT, () => {
     console.log(`서버가 http://localhost:${PORT} 에서 실행 중입니다.`);
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import swaggerUi from 'swagger-ui-express';
 import { getMarkdownHtml } from '@/utils/docs';
 import { pathToFileURL } from 'node:url';
 import * as http from 'node:http';
+import ChatServer from '@/domains/chat/ChatServer';
 
 export async function start() {
   const app = express();
@@ -23,6 +24,7 @@ export async function start() {
   await registerDocumentRoutes(app);
 
   const httpServer = http.createServer(app);
+  new ChatServer(httpServer);
 
   httpServer.listen(PORT, () => {
     console.log(`서버가 http://localhost:${PORT} 에서 실행 중입니다.`);


### PR DESCRIPTION
# 변경점 👍
채팅 서버를 개발했습니다.

## 채팅 시나리오
채팅은 게시글(마커) 조회 -> 게시글을 통한 채팅 진입 -> WebSocket을 이용한 채팅 IO -> 채팅 지속 또는 종료 순으로 진행됩니다.

## 게시글을 통한 채팅 생성
- POST /api/chatrooms에 필요한 내용을 담아 채팅을 생성합니다.
- 생성 시 결과값을 반환하면 클라이언트의 채팅 목록에 저장합니다.
- 클라이언트가 앱에 접속 중인 경우 바로 websocket으로 전송, 아닌 경우 expo token을 이용하여 알림을 전송합니다.
- 이 때 알림을 클릭하면 알림의 payload로 함께 전송하는 채팅방 id값을 이용하여 채팅에 접속하게 하면 됩니다. (이 부분은 아직 미구현)

## 채팅
- 채팅은 websocket을 이용해서 구현했습니다. 따라서, 채팅 탭에 입장했을 때 또는 앱을 켰을 때 `https://서버주소?token=''`로 웹소켓 연결 요청을 보내면 됩니다. 
- 웹소켓 연결이 형성되면, 사용자는 그동안(웹소켓이 연결되기 전) 읽지 않은 채팅을 모두 수신받습니다. 스키마는 따로 명시하겠습니다.

## 채팅 블록
- 다음 이슈인 채팅/게시글 블로킹 관련 이슈에서 다룰 예정입니다.
