### PR TITLE
채팅 로직 수정 및 회원가입 시 필수 기입항목 추가 (ISSUE-131, ISSUE-129, ISSUE-120)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -161,6 +161,11 @@
                   "termsAccepted": {
                     "type": "boolean",
                     "const": true
+                  },
+                  "gender": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 1
                   }
                 },
                 "required": [
@@ -168,7 +173,8 @@
                   "password",
                   "name",
                   "birth",
-                  "termsAccepted"
+                  "termsAccepted",
+                  "gender"
                 ]
               }
             }
@@ -200,6 +206,9 @@
                         "birth": {
                           "type": "string"
                         },
+                        "gender": {
+                          "type": "integer"
+                        },
                         "joinedAt": {
                           "type": "string"
                         },
@@ -218,6 +227,7 @@
                         "email",
                         "name",
                         "birth",
+                        "gender",
                         "joinedAt",
                         "reportedCount",
                         "isDeactivated",
@@ -336,6 +346,9 @@
                         "birth": {
                           "type": "string"
                         },
+                        "gender": {
+                          "type": "integer"
+                        },
                         "joinedAt": {
                           "type": "string"
                         },
@@ -354,6 +367,7 @@
                         "email",
                         "name",
                         "birth",
+                        "gender",
                         "joinedAt",
                         "reportedCount",
                         "isDeactivated",
@@ -763,6 +777,9 @@
                         "birth": {
                           "type": "string"
                         },
+                        "gender": {
+                          "type": "integer"
+                        },
                         "joinedAt": {
                           "type": "string"
                         },
@@ -781,6 +798,7 @@
                         "email",
                         "name",
                         "birth",
+                        "gender",
                         "joinedAt",
                         "reportedCount",
                         "isDeactivated",
@@ -1640,6 +1658,9 @@
                           "peerNickname": {
                             "type": "string"
                           },
+                          "myNickname": {
+                            "type": "string"
+                          },
                           "post": {
                             "type": "object",
                             "properties": {
@@ -1701,13 +1722,18 @@
                               "createdAt",
                               "content"
                             ]
+                          },
+                          "unreadMessageCount": {
+                            "type": "number"
                           }
                         },
                         "required": [
                           "id",
                           "peerNickname",
+                          "myNickname",
                           "post",
-                          "lastMessage"
+                          "lastMessage",
+                          "unreadMessageCount"
                         ]
                       }
                     }

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -106,12 +106,17 @@ paths:
                 termsAccepted:
                   type: boolean
                   const: true
+                gender:
+                  type: integer
+                  minimum: 0
+                  maximum: 1
               required:
                 - email
                 - password
                 - name
                 - birth
                 - termsAccepted
+                - gender
       responses:
         "200":
           description: 회원가입 성공
@@ -133,6 +138,8 @@ paths:
                         type: string
                       birth:
                         type: string
+                      gender:
+                        type: integer
                       joinedAt:
                         type: string
                       reportedCount:
@@ -146,6 +153,7 @@ paths:
                       - email
                       - name
                       - birth
+                      - gender
                       - joinedAt
                       - reportedCount
                       - isDeactivated
@@ -221,6 +229,8 @@ paths:
                         type: string
                       birth:
                         type: string
+                      gender:
+                        type: integer
                       joinedAt:
                         type: string
                       reportedCount:
@@ -234,6 +244,7 @@ paths:
                       - email
                       - name
                       - birth
+                      - gender
                       - joinedAt
                       - reportedCount
                       - isDeactivated
@@ -494,6 +505,8 @@ paths:
                         type: string
                       birth:
                         type: string
+                      gender:
+                        type: integer
                       joinedAt:
                         type: string
                       reportedCount:
@@ -507,6 +520,7 @@ paths:
                       - email
                       - name
                       - birth
+                      - gender
                       - joinedAt
                       - reportedCount
                       - isDeactivated
@@ -1045,6 +1059,8 @@ paths:
                           type: integer
                         peerNickname:
                           type: string
+                        myNickname:
+                          type: string
                         post:
                           type: object
                           properties:
@@ -1089,11 +1105,15 @@ paths:
                           required:
                             - createdAt
                             - content
+                        unreadMessageCount:
+                          type: number
                       required:
                         - id
                         - peerNickname
+                        - myNickname
                         - post
                         - lastMessage
+                        - unreadMessageCount
                 required:
                   - chatrooms
     post:

--- a/examples/chat/index.html
+++ b/examples/chat/index.html
@@ -8,17 +8,25 @@
     #log { white-space: pre-wrap; border: 1px solid #ccc; padding: 10px; height: 300px; overflow-y: auto; margin-bottom: 10px; }
     #inputArea { display: flex; gap: 10px; }
     #inputArea input, #inputArea button { font-size: 1rem; }
+    #connectArea { display: flex; gap: 10px; margin-bottom: 10px; }
+    #connectArea input { font-size: 1rem; }
   </style>
 </head>
 <body>
 
 <h1>WebSocket 채팅 클라이언트</h1>
 
-<label>
-  토큰:
-  <input id="token" placeholder="JWT" style="width: 400px">
-</label>
-<button onclick="connect()">서버 연결</button>
+<div id="connectArea">
+  <label>
+    서버 URL:
+    <input id="serverUrl" placeholder="wss://example.com:1234" style="width: 300px" value="wss://banjjak.me:8444">
+  </label>
+  <label>
+    토큰:
+    <input id="token" placeholder="JWT" style="width: 300px">
+  </label>
+  <button onclick="connect()">서버 연결</button>
+</div>
 
 <div id="log"></div>
 
@@ -39,9 +47,11 @@
 
   function connect() {
     const token = document.getElementById('token').value.trim();
+    const serverUrl = document.getElementById('serverUrl').value.trim();
     if (!token) return alert("토큰을 입력하세요.");
+    if (!serverUrl) return alert("서버 URL을 입력하세요.");
 
-    socket = new WebSocket(`ws://localhost:3000?token=${token}`);
+    socket = new WebSocket(`${serverUrl}?token=${token}`);
 
     socket.addEventListener('open', () => log('✅ 서버에 연결됨'));
     socket.addEventListener('message', (event) => {
@@ -77,6 +87,12 @@
     log(`💬 [보냄] 채팅방 ${chatroomId} → ${content}`);
     document.getElementById('message').value = '';
   }
+
+  document.getElementById('message').addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      sendMessage();
+    }
+  });
 </script>
 
 </body>

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "gen:openapi": "pnpm db:generate && tsx scripts/openapi/index.ts",
     "gen:env": "tsx scripts/env/encode.ts",
     "gen:jwt": "tsx scripts/jwt/index.ts",
-    "seed:posts": "cross-env NODE_ENV=staging tsx scripts/mock/createPost.ts",
+    "seed:posts": "tsx scripts/mock/createPost.ts",
+    "seed:member": "tsx scripts/mock/createMember.ts",
     "prepare": "husky"
   },
   "keywords": [],

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -139,6 +139,7 @@ model Chat {
 
   @@index(chatroomId)
   @@index(createdAt)
+  @@index([chatroomId, receiverId])
   @@map("chats")
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,7 @@ model Member {
   name          String   @map("name") @db.VarChar(20)
   password      String   @map("password") @db.VarChar(88)
   birth         DateTime @default(now())
+  gender        Int      @default(0)
   joinedAt      DateTime @default(now()) @map("joined_at")
   reportedCount Int      @default(0) @map("reported_count")
   isDeactivated Boolean  @default(false) @map("is_deactivated")

--- a/scripts/mock/createMember.ts
+++ b/scripts/mock/createMember.ts
@@ -1,0 +1,65 @@
+import { hashPassword } from '../../src/domains/auth/utils';
+import prisma from '../../src/utils/database';
+
+function parseCountArg(): number {
+  const cIndex = process.argv.indexOf('-c');
+  if (cIndex === -1 || cIndex + 1 >= process.argv.length) {
+    console.error('사용법: tsx create-members.ts -c <멤버 수>');
+    process.exit(1);
+  }
+
+  const count = parseInt(process.argv[cIndex + 1], 10);
+  if (isNaN(count) || count <= 0) {
+    console.error('올바른 멤버 수를 입력하세요.');
+    process.exit(1);
+  }
+
+  return count;
+}
+
+function generateRandomEmail(i: number): string {
+  const timestamp = Date.now();
+  return `user${timestamp}_${i}@example.com`;
+}
+
+function generateRandomName(i: number): string {
+  return `user${i}`;
+}
+
+function generateRandomPassword(): string {
+  return Math.random().toString(36).slice(-10);
+}
+
+async function createRandomMember(i: number) {
+  const email = generateRandomEmail(i);
+  const name = generateRandomName(i);
+  const plainPassword = generateRandomPassword();
+  const hashedPassword = await hashPassword(plainPassword);
+
+  const member = await prisma.member.create({
+    data: {
+      email,
+      name,
+      password: hashedPassword,
+      termsAccepted: true,
+    },
+  });
+
+  console.log(`ID: ${member.id}, Email: ${email}, Name: ${name}, Password: ${plainPassword}`);
+}
+
+async function main() {
+  const count = parseCountArg();
+
+  for (let i = 0; i < count; i++) {
+    await createRandomMember(i);
+  }
+
+  await prisma.$disconnect();
+}
+
+main().catch((e) => {
+  console.error(e);
+  prisma.$disconnect();
+  process.exit(1);
+});

--- a/scripts/mock/createPost.ts
+++ b/scripts/mock/createPost.ts
@@ -4,7 +4,7 @@ async function createRandomPostAndMarker() {
   const randomTitle = `Title ${Math.random().toString(36).substring(7)}`;
   const randomContent = `Content ${Math.random().toString(36).substring(7)}`;
   const randomAddress = `Address ${Math.random().toString(36).substring(7)}`;
-  const authorIds = [2, 3, 7, 9, 10];
+  const authorIds = Array.from({ length: 21 }, (_, i) => i + 12);
   const randomAuthorId = authorIds[Math.floor(Math.random() * authorIds.length)];
 
   const post = await prisma.post.create({

--- a/src/domains/auth/schema.ts
+++ b/src/domains/auth/schema.ts
@@ -27,6 +27,7 @@ export const RegisterRequestBodySchema = MemberSchema.pick({
     /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()_\-+=[{\]};:'",.<>/?\\|`~]).{10,25}$/,
   ),
   email: z.string().email(),
+  gender: z.number().int().min(0).max(1),
 });
 
 export const LoginRequestBodySchema = z.object({

--- a/src/domains/chat/ChatClient.ts
+++ b/src/domains/chat/ChatClient.ts
@@ -12,7 +12,6 @@ import ChatServer, { REDIS_CHANNEL_PREFIX } from '@/domains/chat/ChatServer';
 import prisma from '@/utils/database';
 import { pub } from '@/utils/redis';
 import {
-  findUnreadChats,
   getJoinedChatroomWithId,
 } from '@/domains/chat/service';
 
@@ -29,13 +28,13 @@ export default class ChatClient {
     this._memberId = memberId;
     this.bindEventListeners();
     this.startPingChecker();
-    this.sendUnreadChats();
+    // this.sendUnreadChats();
   }
 
-  async sendUnreadChats() {
-    const chats = await findUnreadChats(this.memberId);
-    this.send({ chats, type: 'unreadChats' });
-  }
+  // async sendUnreadChats() {
+  //   const chats = await findUnreadChats(this.memberId);
+  //   this.send({ chats, type: 'unreadChats' });
+  // }
 
   async handleInboundChat(payload: InboundChat) {
     const { chatroomId, content } = InboundChatSchema.parse(payload);

--- a/src/domains/chat/schema.ts
+++ b/src/domains/chat/schema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { ChatRoomSchema, ChatSchema, PostSchema } from '@/schemas';
 
-export const MessageType = z.enum(['sentChat', 'receivedChat', 'read', 'error', 'publish', 'unreadChats']);
+export const MessageType = z.enum(['sentChat', 'receivedChat', 'read', 'error', 'publish']);
 
 export const ErrorMessageSchema = z.object({
   type: z.literal(MessageType.enum.error),
@@ -29,11 +29,6 @@ export const OutboundChatSchema = z.object({
   })
 );
 
-export const UnreadChatsSchema = z.object({
-  type: z.literal(MessageType.enum.unreadChats),
-  chats: z.array(OutboundChatSchema),
-});
-
 export const PublishableChatSchema = OutboundChatSchema.extend({
   type: z.literal(MessageType.enum.publish),
   senderId: z.number(),
@@ -54,7 +49,6 @@ export const SocketMessageSchema = z.union([
   PublishableChatSchema,
   ReadChatroomMessageSchema,
   ErrorMessageSchema,
-  UnreadChatsSchema,
 ]);
 
 export const CreateChatroomRequestBodySchema = z.object({

--- a/src/domains/chat/schema.ts
+++ b/src/domains/chat/schema.ts
@@ -108,6 +108,7 @@ export const GetChatroomsResponseBodySchema = z.object({
     id: true,
   }).extend({
     peerNickname: z.string(),
+    myNickname: z.string(),
     post: PostSchema.omit({
       authorId: true,
     }),

--- a/src/domains/chat/schema.ts
+++ b/src/domains/chat/schema.ts
@@ -110,5 +110,6 @@ export const GetChatroomsResponseBodySchema = z.object({
       createdAt: true,
       content: true,
     }),
+    unreadMessageCount: z.number(),
   }))
 });

--- a/src/domains/chat/service.ts
+++ b/src/domains/chat/service.ts
@@ -96,15 +96,27 @@ export async function getChatrooms(req: AuthenticatedRequest, res: GetChatroomsR
           senderId: true,
           chatroomId: true,
         }
-      }
+      },
+      _count: {
+        select: {
+          chats: {
+            where: {
+              isRead: false,
+              receiverId: member.id,
+            },
+          },
+        },
+      },
     },
   });
-  const chatroomInfo = chatrooms.map(chatroom => ({
+  const chatroomInfo
+    = chatrooms.map(chatroom => ({
     id: chatroom.id,
     peerNickname: chatroom.authorId === member.id ? chatroom.requesterNickname : chatroom.authorNickname,
     myNickname: chatroom.authorId === member.id ? chatroom.authorNickname : chatroom.requesterNickname,
     post: chatroom.post,
     lastMessage: chatroom.chats[0],
+    unreadMessageCount: chatroom._count.chats,
   }));
   res.status(StatusCodes.OK).json({
     chatrooms: chatroomInfo,

--- a/src/domains/chat/service.ts
+++ b/src/domains/chat/service.ts
@@ -92,6 +92,7 @@ export async function getChatrooms(req: AuthenticatedRequest, res: GetChatroomsR
   const chatroomInfo = chatrooms.map(chatroom => ({
     id: chatroom.id,
     peerNickname: chatroom.authorId === member.id ? chatroom.requesterNickname : chatroom.authorNickname,
+    myNickname: chatroom.authorId === member.id ? chatroom.authorNickname : chatroom.requesterNickname,
     post: chatroom.post,
     lastMessage: chatroom.chats[0],
   }));

--- a/src/domains/chat/service.ts
+++ b/src/domains/chat/service.ts
@@ -123,14 +123,7 @@ export async function createChatroom(req: CreateChatroomRequest, res: CreateChat
     throw new ForbiddenError('채팅방을 개설할 수 없습니다.');
   }
   if(chatroom) {
-    const chat = createPublishableChat(chatroom, member, content);
-    await ChatServer.getInstance().createChat(chat, post.authorId);
-    const outboundChat = createOutboundChat(chat, chatroom);
-    res.status(StatusCodes.OK).json({
-      ...outboundChat,
-      authorNickname: chatroom.authorNickname,
-    });
-    return;
+    throw new BadRequestError('이미 채팅방이 개설되어 있습니다.');
   }
 
   if(post.authorId === member.id) {


### PR DESCRIPTION
# 변경점 👍

## 채팅 관련
- ws 연결 시 더이상 unreadChats를 보내지 않습니다. 대신, 클라이언트가 원하는 시점에 REST API를 통해 최근 채팅을 불러오도록 구현하고 실시간 채팅은 websocket으로 이뤄지도록 변경했습니다.
- 채팅방에 입장하여 채팅을 조회하면 자동으로 채팅이 읽음처리 되도록 수정했습니다. 추후에는 별도의 엔드포인트를 통해 읽음 처리를 좀더 확실히 하는 것이 좋아보입니다.
- 동일한 post에 대해 두 개 이상의 채팅방을 개설하려 할 경우 에러를 발생시키도록 변경했습니다.
- 이제 채팅방 목록을 조회할 경우 읽지 않은 채팅의 개수를 함께 반환합니다.
- 채팅방 조회 시 상대와 자신의 닉네임을 모두 반환합니다.

## 기타
- 회원가입 시 필수 기입 항목으로 성별을 추가했습니다.