### PR TITLE
채팅 조회 시 가장 나중의 채팅 id를 반환 (ISSUE-129)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1589,10 +1589,14 @@
                           "id"
                         ]
                       }
+                    },
+                    "lastChatId": {
+                      "type": "number"
                     }
                   },
                   "required": [
-                    "chats"
+                    "chats",
+                    "lastChatId"
                   ]
                 }
               }

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1016,8 +1016,11 @@ paths:
                         - createdAt
                         - type
                         - id
+                  lastChatId:
+                    type: number
                 required:
                   - chats
+                  - lastChatId
         "403":
           description: 본인이 참여하지 않은 채팅방 정보 조회 시도
           content:

--- a/src/domains/chat/schema.ts
+++ b/src/domains/chat/schema.ts
@@ -94,6 +94,7 @@ export const GetChatsResponseBodySchema = z.object({
     type: z.enum([MessageType.enum.receivedChat, MessageType.enum.sentChat]),
     id: z.number(),
   })),
+  lastChatId: z.number(),
 });
 
 

--- a/src/domains/chat/service.ts
+++ b/src/domains/chat/service.ts
@@ -67,7 +67,8 @@ export async function getChats(req: GetChatsRequest, res: GetChatsResponse) {
     }
   });
   res.status(StatusCodes.OK).json({
-    chats
+    chats,
+    lastChatId: chats[chats.length-1].id,
   });
 }
 


### PR DESCRIPTION
# 변경점 👍

GET /api/chatrooms/:id 요청 시 가장 나중(시간순으로는 가장 처음)의 채팅의 id를 반환하도록 구현했습니다.
