### PR TITLE
채팅 시 websocket이 online이더라도 읽지 않은 상태로 저장 (ISSUE-129)

### DIFF
--- a/src/domains/notification/utils.ts
+++ b/src/domains/notification/utils.ts
@@ -6,18 +6,19 @@ const expo = new Expo({
   accessToken: process.env.EXPO_ACCESS_TOKEN,
 });
 
-export async function sendPushMessage(token: string, title: string, body: string) {
+export async function sendPushMessage(token: string, title: string, body: string, payload?: Record<string, unknown>) {
   const message: ExpoPushMessage = {
     to: token,
     sound: 'default',
     title,
     body,
+    ...(payload ? { data: payload } : {}),
   };
   const [result] = await expo.sendPushNotificationsAsync([message]);
   return result;
 }
 
-export async function sendPushToMember(member: InternalMember, title: string, body: string) {
+export async function sendPushToMember(member: InternalMember, title: string, body: string, payload?: Record<string, unknown>) {
   const { expoToken: token } = member;
   if(! Expo.isExpoPushToken(token)) {
     console.error(`Invalid push token for member id ${member.id}`);
@@ -34,5 +35,5 @@ export async function sendPushToMember(member: InternalMember, title: string, bo
       status: 'error',
     };
   }
-  return sendPushMessage(token, title, body);
+  return sendPushMessage(token, title, body, payload);
 }


### PR DESCRIPTION
# 변경점 👍

- 채팅을 보낼 대상 클라이언트가 온라인일 때에 isRead값을 true로 두고 바로 db에 저장하면 클라이언트 측에서 수신하자마자 읽음 여부에 상관없이 읽음 처리가 됩니다.
- 따라서 클라이언트에서 '읽었다'는 명확한 확인 이후에 읽음 상태로 변경하도록 수정했습니다.