### PR TITLE
채팅방 비활성화 및 읽지 않은 채팅 유무 확인 (ISSUE-129)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -791,6 +791,9 @@
                         },
                         "termsAccepted": {
                           "type": "boolean"
+                        },
+                        "hasUnreadChat": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
@@ -802,7 +805,8 @@
                         "joinedAt",
                         "reportedCount",
                         "isDeactivated",
-                        "termsAccepted"
+                        "termsAccepted",
+                        "hasUnreadChat"
                       ]
                     }
                   },
@@ -1516,6 +1520,49 @@
       }
     },
     "/api/chatrooms/:id": {
+      "delete": {
+        "summary": "채팅방 비활성화 (나가기)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": true,
+            "description": "Bearer 토큰",
+            "schema": {
+              "type": "string",
+              "example": "Bearer <your-jwt>"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "채팅방 나가기 완료"
+          },
+          "403": {
+            "description": "본인이 참여하지 않은 채팅방 나가기 시도",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
       "get": {
         "summary": "채팅방의 채팅 내역 반환. 채팅 id값이 cursor-(limit+1)~cursor-1 인 채팅을 반환.",
         "security": [

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -515,6 +515,8 @@ paths:
                         type: boolean
                       termsAccepted:
                         type: boolean
+                      hasUnreadChat:
+                        type: boolean
                     required:
                       - id
                       - email
@@ -525,6 +527,7 @@ paths:
                       - reportedCount
                       - isDeactivated
                       - termsAccepted
+                      - hasUnreadChat
                 required:
                   - member
         "401":
@@ -964,6 +967,32 @@ paths:
                 required:
                   - message
   /api/chatrooms/:id:
+    delete:
+      summary: 채팅방 비활성화 (나가기)
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: header
+          name: Authorization
+          required: true
+          description: Bearer 토큰
+          schema:
+            type: string
+            example: Bearer <your-jwt>
+      responses:
+        "200":
+          description: 채팅방 나가기 완료
+        "403":
+          description: 본인이 참여하지 않은 채팅방 나가기 시도
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                required:
+                  - message
     get:
       summary: 채팅방의 채팅 내역 반환. 채팅 id값이 cursor-(limit+1)~cursor-1 인 채팅을 반환.
       security:

--- a/scripts/openapi/chats/index.ts
+++ b/scripts/openapi/chats/index.ts
@@ -11,6 +11,24 @@ import { ErrorSchema } from '../../../src/domains/error/schema';
 
 export const chatApiPaths = {
   [`${currentApiPrefix}/chatrooms/:id`]: {
+    delete: {
+      summary: '채팅방 비활성화 (나가기)',
+      security: [{ bearerAuth: [] }],
+      parameters: [tokenHeader],
+      responses: {
+        200: {
+          description: '채팅방 나가기 완료',
+        },
+        403: {
+          description: '본인이 참여하지 않은 채팅방 나가기 시도',
+          content: {
+            'application/json': {
+              schema: ErrorSchema,
+            }
+          }
+        }
+      }
+    },
     get: {
       summary: '채팅방의 채팅 내역 반환. 채팅 id값이 cursor-(limit+1)~cursor-1 인 채팅을 반환.',
       security: [{ bearerAuth: [] }],

--- a/src/domains/chat/controller.ts
+++ b/src/domains/chat/controller.ts
@@ -1,11 +1,17 @@
 import express from 'express';
 import { authMiddleware } from '@/domains/auth/middleware';
-import { createChatroom, getChatrooms, getChats } from '@/domains/chat/service';
+import {
+  createChatroom,
+  deactivateChatroom,
+  getChatrooms,
+  getChats,
+} from '@/domains/chat/service';
 
 const chatController = express.Router();
 
 chatController.post('/chatrooms', authMiddleware, createChatroom);
 chatController.get('/chatrooms', authMiddleware, getChatrooms);
 chatController.get('/chatrooms/:id', authMiddleware, getChats);
+chatController.delete('/chatrooms/:id', authMiddleware, deactivateChatroom);
 
 export default chatController;

--- a/src/domains/chat/schema.ts
+++ b/src/domains/chat/schema.ts
@@ -97,6 +97,15 @@ export const GetChatsResponseBodySchema = z.object({
   lastChatId: z.number(),
 });
 
+export const DeactivateChatroomRequestPathSchema = z.object({
+  id: z.preprocess(val => {
+    if (typeof val === 'string' && /^\d+$/.test(val)) {
+      return Number(val);
+    }
+    return val;
+  }, z.number().int().min(1)),
+});
+
 
 export const GetChatroomsResponseBodySchema = z.object({
   chatrooms: z.array(ChatRoomSchema.pick({

--- a/src/domains/chat/types.d.ts
+++ b/src/domains/chat/types.d.ts
@@ -6,13 +6,12 @@ import {
   OutboundChatSchema,
   ErrorMessageSchema,
   PublishableChatSchema,
-  UnreadChatsSchema,
   CreateChatroomRequestBodySchema,
   CreateChatroomResponseSchema,
   GetChatroomsResponseBodySchema,
   GetChatsRequestPathSchema,
   GetChatsRequestQuerySchema,
-  GetChatsResponseBodySchema,
+  GetChatsResponseBodySchema, DeactivateChatroomRequestPathSchema,
 } from '@/domains/chat/schema';
 import { AuthenticatedRequest } from '@/domains/auth/types';
 import { Response } from 'express';
@@ -32,5 +31,7 @@ export type GetChatroomsResponse = Response<z.infer<typeof GetChatroomsResponseB
 
 export type GetChatsRequest = AuthenticatedRequest<z.infer<typeof GetChatsRequestPathSchema>, {}, z.infer<typeof GetChatsRequestQuerySchema>>;
 export type GetChatsResponse = Response<z.infer<typeof GetChatsResponseBodySchema>>;
+
+export type DeactivateChatroomRequest = AuthenticatedRequest<z.infer<typeof DeactivateChatroomRequestPathSchema>>;
 
 export type UnreadChats = z.infer<typeof UnreadChatsSchema>;

--- a/src/domains/member/schema.ts
+++ b/src/domains/member/schema.ts
@@ -4,7 +4,9 @@ import { z } from 'zod';
 export const PublicMemberSchema = MemberSchema.omit({ password: true, expoToken: true });
 export const InternalMemberSchema = MemberSchema.omit({ password: true });
 export const GetMyInfoSchema = z.object({
-  member: PublicMemberSchema
+  member: PublicMemberSchema.extend({
+    hasUnreadChat: z.boolean(),
+  }),
 });
 
 export const GetActivePostCountResponseBodySchema = z.object({

--- a/src/domains/member/service.ts
+++ b/src/domains/member/service.ts
@@ -7,7 +7,19 @@ import { StatusCodes } from 'http-status-codes';
 import { omitPrivateFields } from '@/domains/member/utils';
 
 export async function getMyInfo(req: AuthenticatedRequest, res: GetMyInfoResponse) {
-  res.status(StatusCodes.OK).json({ member: omitPrivateFields(req.member!) });
+  const member = omitPrivateFields(req.member!);
+  const hasUnreadChat = (await prisma.chat.count({
+    where: {
+      receiverId: member.id,
+      isRead: false,
+    }
+  })) > 0;
+  res.status(StatusCodes.OK).json({
+    member: {
+      ...member,
+      hasUnreadChat
+    }
+  });
 }
 
 export async function getActivePostCount(req: AuthenticatedRequest, res: GetActivePostCountResponse) {


### PR DESCRIPTION
# 변경점 👍
- 읽지 않은 채팅의 유무 여부를 GET /members/me에서 함께 반환합니다.
- 채팅방 비활성화 api를 작성했습니다.
