### PR TITLE
채팅방 관련 이슈 해결 및 사용자 기관 정보 반환 (ISSUE-129)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -220,6 +220,9 @@
                         },
                         "termsAccepted": {
                           "type": "boolean"
+                        },
+                        "institutionId": {
+                          "type": "integer"
                         }
                       },
                       "required": [
@@ -231,7 +234,8 @@
                         "joinedAt",
                         "reportedCount",
                         "isDeactivated",
-                        "termsAccepted"
+                        "termsAccepted",
+                        "institutionId"
                       ]
                     },
                     "token": {
@@ -360,6 +364,9 @@
                         },
                         "termsAccepted": {
                           "type": "boolean"
+                        },
+                        "institutionId": {
+                          "type": "integer"
                         }
                       },
                       "required": [
@@ -371,7 +378,8 @@
                         "joinedAt",
                         "reportedCount",
                         "isDeactivated",
-                        "termsAccepted"
+                        "termsAccepted",
+                        "institutionId"
                       ]
                     },
                     "token": {
@@ -792,8 +800,42 @@
                         "termsAccepted": {
                           "type": "boolean"
                         },
+                        "institutionId": {
+                          "type": "integer"
+                        },
                         "hasUnreadChat": {
                           "type": "boolean"
+                        },
+                        "institution": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "emailDomain": {
+                              "type": "string"
+                            },
+                            "isActive": {
+                              "type": "boolean"
+                            },
+                            "createdAt": {
+                              "type": "string"
+                            },
+                            "updatedAt": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "name",
+                            "emailDomain",
+                            "isActive",
+                            "createdAt",
+                            "updatedAt"
+                          ]
                         }
                       },
                       "required": [
@@ -806,6 +848,7 @@
                         "reportedCount",
                         "isDeactivated",
                         "termsAccepted",
+                        "institutionId",
                         "hasUnreadChat"
                       ]
                     }

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -148,6 +148,8 @@ paths:
                         type: boolean
                       termsAccepted:
                         type: boolean
+                      institutionId:
+                        type: integer
                     required:
                       - id
                       - email
@@ -158,6 +160,7 @@ paths:
                       - reportedCount
                       - isDeactivated
                       - termsAccepted
+                      - institutionId
                   token:
                     type: string
                 required:
@@ -239,6 +242,8 @@ paths:
                         type: boolean
                       termsAccepted:
                         type: boolean
+                      institutionId:
+                        type: integer
                     required:
                       - id
                       - email
@@ -249,6 +254,7 @@ paths:
                       - reportedCount
                       - isDeactivated
                       - termsAccepted
+                      - institutionId
                   token:
                     type: string
                 required:
@@ -515,8 +521,32 @@ paths:
                         type: boolean
                       termsAccepted:
                         type: boolean
+                      institutionId:
+                        type: integer
                       hasUnreadChat:
                         type: boolean
+                      institution:
+                        type: object
+                        properties:
+                          id:
+                            type: integer
+                          name:
+                            type: string
+                          emailDomain:
+                            type: string
+                          isActive:
+                            type: boolean
+                          createdAt:
+                            type: string
+                          updatedAt:
+                            type: string
+                        required:
+                          - id
+                          - name
+                          - emailDomain
+                          - isActive
+                          - createdAt
+                          - updatedAt
                     required:
                       - id
                       - email
@@ -527,6 +557,7 @@ paths:
                       - reportedCount
                       - isDeactivated
                       - termsAccepted
+                      - institutionId
                       - hasUnreadChat
                 required:
                   - member

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,17 +25,19 @@ model Member {
   isDeactivated Boolean  @default(false) @map("is_deactivated")
   termsAccepted Boolean  @default(false) @map("terms_accepted")
   expoToken     String?  @map("expo_token") @db.VarChar(255)
+  institutionId Int      @default(1) @map("institution_id")
 
   posts              Post[]
   likes              Like[]
-  authoredChatRooms  ChatRoom[] @relation("AuthoredRooms")
-  requestedChatRooms ChatRoom[] @relation("RequestedRooms")
-  sentChats          Chat[]     @relation("SentChats")
-  receivedChats      Chat[]     @relation("ReceivedChats")
-  createdReports     Report[]   @relation("CreatedReports")
-  reportedReports    Report[]   @relation("ReportedReports")
-  issuedBlocks       Block[]    @relation("IssuedBlocks")
-  targetedBlocks     Block[]    @relation("TargetedBlocks")
+  authoredChatRooms  ChatRoom[]  @relation("AuthoredRooms")
+  requestedChatRooms ChatRoom[]  @relation("RequestedRooms")
+  sentChats          Chat[]      @relation("SentChats")
+  receivedChats      Chat[]      @relation("ReceivedChats")
+  createdReports     Report[]    @relation("CreatedReports")
+  reportedReports    Report[]    @relation("ReportedReports")
+  issuedBlocks       Block[]     @relation("IssuedBlocks")
+  targetedBlocks     Block[]     @relation("TargetedBlocks")
+  institution        Institution @relation(fields: [institutionId], references: [id], onDelete: NoAction)
 
   @@map("members")
 }
@@ -173,6 +175,7 @@ model Institution {
   createdAt   DateTime           @default(now()) @map("created_at")
   updatedAt   DateTime           @default(now()) @updatedAt @map("updated_at")
   bounds      InstitutionBound[]
+  members     Member[]
 
   @@map("institutions")
 }

--- a/src/domains/chat/ChatClient.ts
+++ b/src/domains/chat/ChatClient.ts
@@ -45,7 +45,7 @@ export default class ChatClient {
       return;
     }
     if(chatroom.isDeactivated) {
-      this.sendError('종료된 채팅방입니다. 더이상 메시지를 보낼 수 없습니다.');
+      this.sendChatroomError('종료된 채팅방입니다. 더이상 메시지를 보낼 수 없습니다.', chatroomId);
       return;
     }
     // sender가 아닌 사용자가 receiver
@@ -108,10 +108,15 @@ export default class ChatClient {
     });
   }
 
-  sendError(message: string) {
+  sendChatroomError(message: string, chatroomId: number) {
+    this.sendError(message, { chatroomId });
+  }
+
+  sendError(message: string, payload: Record<string, unknown> = {}) {
     this.send({
       type: 'error',
       message,
+      ...payload
     });
   }
 

--- a/src/domains/chat/schema.ts
+++ b/src/domains/chat/schema.ts
@@ -8,6 +8,10 @@ export const ErrorMessageSchema = z.object({
   message: z.string(),
 });
 
+export const ChatroomErrorMessageSchema = ErrorMessageSchema.extend({
+  chatroomId: z.number(),
+});
+
 export const InboundChatSchema = z.object({
   type: z.literal(MessageType.enum.sentChat),
 }).merge(
@@ -49,6 +53,7 @@ export const SocketMessageSchema = z.union([
   PublishableChatSchema,
   ReadChatroomMessageSchema,
   ErrorMessageSchema,
+  ChatroomErrorMessageSchema,
 ]);
 
 export const CreateChatroomRequestBodySchema = z.object({

--- a/src/domains/chat/service.ts
+++ b/src/domains/chat/service.ts
@@ -77,6 +77,7 @@ export async function getChatrooms(req: AuthenticatedRequest, res: GetChatroomsR
   const member = req.member!;
   const chatrooms = await prisma.chatRoom.findMany({
     where: {
+      isDeactivated: false,
       OR: [{ authorId: member.id }, { requesterId: member.id }],
     },
     select: {
@@ -85,7 +86,7 @@ export async function getChatrooms(req: AuthenticatedRequest, res: GetChatroomsR
       authorNickname: true,
       requesterNickname: true,
       id: true,
-      isDeactivated: false,
+      isDeactivated: true,
       post: {
         omit: {
           authorId: true,

--- a/src/domains/member/schema.ts
+++ b/src/domains/member/schema.ts
@@ -1,4 +1,4 @@
-import { MemberSchema} from '@/schemas';
+import { InstitutionSchema, MemberSchema } from '@/schemas';
 import { z } from 'zod';
 
 export const PublicMemberSchema = MemberSchema.omit({ password: true, expoToken: true });
@@ -6,6 +6,7 @@ export const InternalMemberSchema = MemberSchema.omit({ password: true });
 export const GetMyInfoSchema = z.object({
   member: PublicMemberSchema.extend({
     hasUnreadChat: z.boolean(),
+    institution: InstitutionSchema.optional(),
   }),
 });
 

--- a/src/domains/member/service.ts
+++ b/src/domains/member/service.ts
@@ -14,9 +14,15 @@ export async function getMyInfo(req: AuthenticatedRequest, res: GetMyInfoRespons
       isRead: false,
     }
   })) > 0;
+  const institution = await prisma.institution.findUnique({
+    where: {
+      id: member.institutionId,
+    }
+  });
   res.status(StatusCodes.OK).json({
     member: {
       ...member,
+      ...(institution ? { institution } : {}),
       hasUnreadChat
     }
   });


### PR DESCRIPTION
# 변경점 👍
- 채팅방 목록에서 종료된 채팅방도 보이던 이슈를 해결했습니다.
- 이제 채팅방에 메시지 전송 후 서버쪽에서 오류가 발생할 경우 에러 정보에 채팅방 ID를 함께 반환합니다.
- 사용자 정보 등록 시 institution 정보를 자동으로 등록하며, 정보 조회시 함께 반환합니다.