### PR TITLE
등록된 학교 정보 반환 스키마 수정 (ISSUE-147)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -594,8 +594,8 @@
                   "type": "object",
                   "properties": {
                     "bounds": {
-                      "type": "array",
-                      "items": {
+                      "type": "object",
+                      "additionalProperties": {
                         "type": "object",
                         "properties": {
                           "id": {

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -393,8 +393,8 @@ paths:
                 type: object
                 properties:
                   bounds:
-                    type: array
-                    items:
+                    type: object
+                    additionalProperties:
                       type: object
                       properties:
                         id:

--- a/src/domains/institution/schema.ts
+++ b/src/domains/institution/schema.ts
@@ -9,6 +9,8 @@ export const GetInstitutionsResponseBodySchema = z.object({
   })),
 });
 
+export const InstitutionBoundRecordSchema = z.record(z.number(), InstitutionBoundSchema);
+
 export const GetInstitutionBoundsResponseBodySchema = z.object({
-  bounds: z.array(InstitutionBoundSchema),
+  bounds: InstitutionBoundRecordSchema,
 });

--- a/src/domains/institution/service.ts
+++ b/src/domains/institution/service.ts
@@ -5,6 +5,7 @@ import {
 import prisma from '@/utils/database';
 import { AuthenticatedRequest } from '@/domains/auth/types';
 import { StatusCodes } from 'http-status-codes';
+import { InstitutionBound } from '@/schemas';
 
 export async function getInstitutions(_: AuthenticatedRequest, res: GetInstitutionsResponse) {
   const institutions = await prisma.institution.findMany();
@@ -14,7 +15,10 @@ export async function getInstitutions(_: AuthenticatedRequest, res: GetInstituti
 }
 
 export async function getInstitutionBounds(_: AuthenticatedRequest, res: GetInstitutionBoundsResponse) {
-  const bounds = await prisma.institutionBound.findMany();
+  const bounds: Record<number, InstitutionBound> = {};
+  (await prisma.institutionBound.findMany()).forEach(bound => {
+    bounds[bound.institutionId] = bound;
+  });
   res.status(StatusCodes.OK).json({
     bounds,
   });


### PR DESCRIPTION
# 변경점 👍

등록된 학교의 경계 정보 조회 시, 경계값 array가 아닌 { 기관id: 경계 정보 }를 반환하도록 수정했습니다.
