### PR TITLE
채팅 및 api 호출 횟수 제한 (ISSUE-151)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1355,7 +1355,8 @@
                 "required": [
                   "reportType",
                   "reason"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
           }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1016,6 +1016,55 @@
         }
       }
     },
+    "/api/posts/availability": {
+      "get": {
+        "summary": "게시글 생성 가능 여부 조회",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": true,
+            "description": "Bearer 토큰",
+            "schema": {
+              "type": "string",
+              "example": "Bearer <your-jwt>"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "게시글 생성 가능 여부 (10분 간격, 24시간 내 최대 10개)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "isAvailable": {
+                      "type": "boolean"
+                    },
+                    "nextAvailableAt": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "isAvailable",
+                    "nextAvailableAt"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/posts/{postId}": {
       "get": {
         "summary": "게시글 단일 조회",
@@ -1282,7 +1331,7 @@
             }
           },
           "400": {
-            "description": "요청 오류",
+            "description": "요청 오류 또는 게시글 생성 불가능",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -662,6 +662,36 @@ paths:
                     type: string
                 required:
                   - message
+  /api/posts/availability:
+    get:
+      summary: 게시글 생성 가능 여부 조회
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: header
+          name: Authorization
+          required: true
+          description: Bearer 토큰
+          schema:
+            type: string
+            example: Bearer <your-jwt>
+      responses:
+        "200":
+          description: 게시글 생성 가능 여부 (10분 간격, 24시간 내 최대 10개)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  isAvailable:
+                    type: boolean
+                  nextAvailableAt:
+                    type:
+                      - string
+                      - "null"
+                required:
+                  - isAvailable
+                  - nextAvailableAt
   /api/posts/{postId}:
     get:
       summary: 게시글 단일 조회
@@ -838,7 +868,7 @@ paths:
                   - postId
                   - markerId
         "400":
-          description: 요청 오류
+          description: 요청 오류 또는 게시글 생성 불가능
           content:
             application/json:
               schema:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -886,6 +886,7 @@ paths:
               required:
                 - reportType
                 - reason
+              additionalProperties: false
       responses:
         "201":
           description: 신고 등록 성공

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "marked": "^15.0.11",
     "morgan": "^1.10.0",
     "node-cron": "^4.0.5",
+    "rate-limiter-flexible": "^7.1.1",
     "rotating-file-stream": "^3.2.6",
     "swagger-ui-express": "^5.0.1",
     "ws": "^8.18.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       node-cron:
         specifier: ^4.0.5
         version: 4.0.5
+      rate-limiter-flexible:
+        specifier: ^7.1.1
+        version: 7.1.1
       rotating-file-stream:
         specifier: ^3.2.6
         version: 3.2.6
@@ -1757,6 +1760,9 @@ packages:
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
+
+  rate-limiter-flexible@7.1.1:
+    resolution: {integrity: sha512-lsYRcqRSJrKBNt6pMzBJTiCJP5KnwsGWdObMZxd19JFUJRntM+yuHs4/2bs6NZweSLgpsDcykvzyQaumoslWQg==}
 
   raw-body@3.0.0:
     resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
@@ -4147,6 +4153,8 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   range-parser@1.2.1: {}
+
+  rate-limiter-flexible@7.1.1: {}
 
   raw-body@3.0.0:
     dependencies:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,6 +65,8 @@ model Post {
   likes    Like[]
   blocks   Block[]
 
+  @@index(createdAt)
+
   @@map("posts")
 }
 

--- a/scripts/mock/createPost.ts
+++ b/scripts/mock/createPost.ts
@@ -7,8 +7,8 @@ async function createRandomPostAndMarker() {
   const authorIds = Array.from({ length: 21 }, (_, i) => i + 12);
   const randomAuthorId = authorIds[Math.floor(Math.random() * authorIds.length)];
 
-  const baseLat = 35.237145278897785;
-  const baseLon = 129.07761905755973;
+  const baseLat = 35.235789;
+  const baseLon = 129.081399;
   const noise = () => (Math.random() - 0.5) * 0.001;
 
   const marker = await prisma.marker.create({

--- a/scripts/mock/createPost.ts
+++ b/scripts/mock/createPost.ts
@@ -5,6 +5,7 @@ async function createRandomPostAndMarker() {
   const randomContent = `Content ${Math.random().toString(36).substring(7)}`;
   const randomAddress = `Address ${Math.random().toString(36).substring(7)}`;
   const authorIds = Array.from({ length: 21 }, (_, i) => i + 12);
+  const markerIdx = Math.floor(Math.random() * 4);
   const randomAuthorId = authorIds[Math.floor(Math.random() * authorIds.length)];
 
   const baseLat = 35.235789;
@@ -25,7 +26,8 @@ async function createRandomPostAndMarker() {
       title: randomTitle,
       content: randomContent,
       expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7일 후
-      address: randomAddress
+      address: randomAddress,
+      markerIdx,
     }
   });
 

--- a/scripts/openapi/post/index.ts
+++ b/scripts/openapi/post/index.ts
@@ -2,13 +2,30 @@ import { currentApiPrefix } from '../../../src/constants';
 import { tokenHeader } from '../headers';
 import {
   CreatePostRequestBodySchema,
-  CreatePostResponseBodySchema,
+  CreatePostResponseBodySchema, GetCreationAvailabilityResponseBodySchema,
   GetPostResponseSchema,
 } from '../../../src/domains/post/schema';
 import { ErrorSchema } from '../../../src/domains/error/schema';
 import { ZodOpenApiPathsObject } from 'zod-openapi';
 
 export const postApiPaths: ZodOpenApiPathsObject = {
+  [`${currentApiPrefix}/posts/availability`]: {
+    get: {
+      summary: '게시글 생성 가능 여부 조회',
+      security: [{bearerAuth: []}],
+      parameters: [tokenHeader],
+      responses: {
+        200: {
+          description: '게시글 생성 가능 여부 (10분 간격, 24시간 내 최대 10개)',
+          content: {
+            'application/json': {
+              schema: GetCreationAvailabilityResponseBodySchema,
+            },
+          },
+        },
+      },
+    }
+  },
   [`${currentApiPrefix}/posts/{postId}`]: {
     get: {
       summary: '게시글 단일 조회',
@@ -83,7 +100,7 @@ export const postApiPaths: ZodOpenApiPathsObject = {
           },
         },
         400: {
-          description: '요청 오류',
+          description: '요청 오류 또는 게시글 생성 불가능',
           content: {
             'application/json': {
               schema: ErrorSchema,

--- a/src/domains/chat/utils.ts
+++ b/src/domains/chat/utils.ts
@@ -1,3 +1,5 @@
+import { RateLimiterMemory } from 'rate-limiter-flexible';
+
 export function createAuthorNickname(): string {
   return `반짝이 관측자 ${generateRandomDigits(4)}`;
 }
@@ -11,3 +13,9 @@ function generateRandomDigits(length: number): string {
   .toString()
   .padStart(length, '0');
 }
+
+export const chatRateLimiter = new RateLimiterMemory({
+  points: 5,
+  duration: 1,
+}); // 1초당 5개까지 허용
+

--- a/src/domains/post/controller.ts
+++ b/src/domains/post/controller.ts
@@ -1,11 +1,17 @@
 import express from 'express';
-import { createPost, deletePost, getPost } from '@/domains/post/service';
+import {
+  createPost,
+  deletePost,
+  getCreationAvailability,
+  getPost,
+} from '@/domains/post/service';
 import { authMiddleware } from '@/domains/auth/middleware';
 
 const postRouter = express.Router();
 
 const apiPrefix = '/posts';
 
+postRouter.get(`${apiPrefix}/availability`, authMiddleware, getCreationAvailability);
 postRouter.get(`${apiPrefix}/:postId`, authMiddleware, getPost);
 postRouter.delete(`${apiPrefix}/:postId`, authMiddleware, deletePost);
 postRouter.post(`${apiPrefix}`, authMiddleware, createPost);

--- a/src/domains/post/schema.ts
+++ b/src/domains/post/schema.ts
@@ -16,6 +16,11 @@ export const GetPostResponseSchema = PostSchema.omit({
   authorId: true,
 }).extend({ isWrittenBySelf: z.boolean(), isLikedBySelf: z.boolean() });
 
+export const GetCreationAvailabilityResponseBodySchema = z.object({
+  isAvailable: z.boolean(),
+  nextAvailableAt: z.coerce.date().nullable(),
+});
+
 export const CreatePostRequestBodySchema = z.object({
   title: z.string().max(63),
   content: z.string().max(255),

--- a/src/domains/post/types.d.ts
+++ b/src/domains/post/types.d.ts
@@ -3,7 +3,9 @@ import { z } from 'zod';
 import { Response } from 'express';
 import {
   CreatePostRequestBodySchema,
-  CreatePostResponseBodySchema, DeletePostPathSchema,
+  CreatePostResponseBodySchema,
+  DeletePostPathSchema,
+  GetCreationAvailabilityResponseBodySchema,
   GetPostPathSchema,
   GetPostResponseSchema,
 } from '@/domains/post/schema';
@@ -15,3 +17,5 @@ export type DeletePostRequest = AuthenticatedRequest<z.infer<typeof DeletePostPa
 
 export type CreatePostRequest = AuthenticatedRequest<{}, z.infer<typeof CreatePostRequestBodySchema>>;
 export type CreatePostResponse = Response<z.infer<typeof CreatePostResponseBodySchema>>;
+
+export type GetCreationAvailabilityResponse = Response<z.infer<typeof GetCreationAvailabilityResponseBodySchema>>;

--- a/src/domains/report/schema.ts
+++ b/src/domains/report/schema.ts
@@ -8,4 +8,4 @@ export const CreateReportRequestBodySchema = ReportSchema.omit({
 }).partial({
   chatroomId: true,
   postId: true,
-});
+}).strict();

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,7 @@ export async function scheduleCronJobs() {
 
 export async function registerRoutes(app: express.Application) {
   app.use(await loadRouters());
+  app.use(errorHandler);
 }
 
 export async function loadRouters() {
@@ -99,7 +100,6 @@ export async function loadRouters() {
     }
   }
 
-  apiRouter.use(currentApiPrefix, errorHandler);
   return apiRouter;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { getMarkdownHtml } from '@/utils/docs';
 import { pathToFileURL } from 'node:url';
 import * as http from 'node:http';
 import ChatServer from '@/domains/chat/ChatServer';
+import rateLimit from 'express-rate-limit';
 
 export async function start() {
   const app = express();
@@ -18,6 +19,7 @@ export async function start() {
   app.use(express.json());
   app.set('trust proxy', 1);
 
+  await registerBaseLimiter(app);
   // domain 내부 컨트롤러들 등록
   await registerRoutes(app);
   // privacy policy, tos, api docs
@@ -30,6 +32,17 @@ export async function start() {
   httpServer.listen(PORT, () => {
     console.log(`서버가 http://localhost:${PORT} 에서 실행 중입니다.`);
   });
+}
+
+export async function registerBaseLimiter(app: express.Application) {
+  const apiRateLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    limit: 100, // 1분에 100번 요청 가능
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: '요청이 너무 많습니다. 잠시 후 다시 시도하세요.',
+  });
+  app.use(currentApiPrefix, apiRateLimiter);
 }
 
 export async function registerDocumentRoutes(app: express.Application) {


### PR DESCRIPTION
# 변경점 👍
- 채팅 및 api 요청의 횟수를 제한합니다. 채팅은 1초에 최대 5개, api 요청은 1분에 최대 100번까지 가능합니다.
- 게시글 생성 횟수를 제한합니다. 게시글은 10분에 한 개씩 생성할 수 있으며, 24시간에 최대 10개까지 생성이 가능합니다.
- 게시글 생성 가능 여부를 클라이언트측에 알려주기 위해, 별도의 엔드포인트를 만들었습니다. (GET /api/posts/availability)