### PR TITLE
채팅이 존재하지 않을 때 lastChatId를 잘못 반환하던 문제점 수정 (ISSUE-158)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1826,8 +1826,7 @@
                     }
                   },
                   "required": [
-                    "chats",
-                    "lastChatId"
+                    "chats"
                   ]
                 }
               }

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1177,7 +1177,6 @@ paths:
                     type: number
                 required:
                   - chats
-                  - lastChatId
         "403":
           description: 본인이 참여하지 않은 채팅방 정보 조회 시도
           content:

--- a/src/domains/chat/schema.ts
+++ b/src/domains/chat/schema.ts
@@ -99,7 +99,7 @@ export const GetChatsResponseBodySchema = z.object({
     type: z.enum([MessageType.enum.receivedChat, MessageType.enum.sentChat]),
     id: z.number(),
   })),
-  lastChatId: z.number(),
+  lastChatId: z.number().optional(),
 });
 
 export const DeactivateChatroomRequestPathSchema = z.object({

--- a/src/domains/chat/service.ts
+++ b/src/domains/chat/service.ts
@@ -69,7 +69,7 @@ export async function getChats(req: GetChatsRequest, res: GetChatsResponse) {
   });
   res.status(StatusCodes.OK).json({
     chats,
-    lastChatId: chats[chats.length-1].id,
+    lastChatId: chats[chats.length-1]?.id,
   });
 }
 


### PR DESCRIPTION
# 버그 해결 💊
이제 채팅방의 채팅 내역이 더이상 존재하지 않을 때, lastChatId를 undefined로 반환합니다.