### PR TITLE
채팅이 더이상 없을 경우 lastChatId로 cursor을 그대로 반환하도록 구현 (ISSUE-158)

### DIFF
--- a/src/domains/chat/service.ts
+++ b/src/domains/chat/service.ts
@@ -67,9 +67,10 @@ export async function getChats(req: GetChatsRequest, res: GetChatsResponse) {
       isRead: true,
     }
   });
+  const lastChat = chats[chats.length-1];
   res.status(StatusCodes.OK).json({
     chats,
-    lastChatId: chats[chats.length-1]?.id,
+    lastChatId: lastChat ? lastChat.id : cursor,
   });
 }
 


### PR DESCRIPTION
# 변경점 👍
채팅을 조회했을 때, cursor 기준으로 이전의 채팅이 더이상 없는 경우 lastChatId 필드로 cursor을 그대로 반환하도록 변경했습니다. 이제 더이상 undefined를 반환하지 않습니다.