### PR TITLE
비밀번호 재설정 구현 (ISSUE-161)

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -17,6 +17,42 @@
     }
   ],
   "paths": {
+    "/api/password": {
+      "put": {
+        "summary": "패스워드 변경 요청 (이메일 인증 선행 필요)",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "password": {
+                    "type": "string",
+                    "pattern": "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_\\-+=[{\\]};:'\",.<>/?\\\\|`~]).{10,25}$",
+                    "minLength": 10,
+                    "maxLength": 25
+                  }
+                },
+                "required": [
+                  "email",
+                  "password"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "패스워드 변경 성공"
+          }
+        }
+      }
+    },
     "/api/verify-email": {
       "post": {
         "summary": "이메일 인증 코드 요청",
@@ -30,10 +66,18 @@
                   "email": {
                     "type": "string",
                     "format": "email"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "REGISTER",
+                      "RESET_PASSWORD"
+                    ]
                   }
                 },
                 "required": [
-                  "email"
+                  "email",
+                  "type"
                 ]
               }
             }
@@ -97,11 +141,19 @@
                   "code": {
                     "type": "string",
                     "maxLength": 6
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "REGISTER",
+                      "RESET_PASSWORD"
+                    ]
                   }
                 },
                 "required": [
                   "email",
-                  "code"
+                  "code",
+                  "type"
                 ]
               }
             }

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -9,6 +9,30 @@ servers:
   - url: https://banjjak.me:8444
     description: 개발 서버
 paths:
+  /api/password:
+    put:
+      summary: 패스워드 변경 요청 (이메일 인증 선행 필요)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+                password:
+                  type: string
+                  pattern: ^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()_\-+=[{\]};:'",.<>/?\\|`~]).{10,25}$
+                  minLength: 10
+                  maxLength: 25
+              required:
+                - email
+                - password
+      responses:
+        "200":
+          description: 패스워드 변경 성공
   /api/verify-email:
     post:
       summary: 이메일 인증 코드 요청
@@ -22,8 +46,14 @@ paths:
                 email:
                   type: string
                   format: email
+                type:
+                  type: string
+                  enum: &a1
+                    - REGISTER
+                    - RESET_PASSWORD
               required:
                 - email
+                - type
       responses:
         "201":
           description: 인증 코드 전송 성공
@@ -64,9 +94,13 @@ paths:
                 code:
                   type: string
                   maxLength: 6
+                type:
+                  type: string
+                  enum: *a1
               required:
                 - email
                 - code
+                - type
       responses:
         "201":
           description: 인증 성공

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -156,6 +156,7 @@ model EmailVerification {
   email              String   @map("email") @db.VarChar(255)
   createdAt          DateTime @default(now()) @map("created_at")
   expiresAt          DateTime @map("expires_at")
+  type               VerificationType @default(REGISTER)
 
   @@index([email])
   @@map("verifications")
@@ -222,4 +223,9 @@ model Report {
 enum ReportType {
   POST_REPORT
   CHATROOM_REPORT
+}
+
+enum VerificationType {
+  REGISTER
+  RESET_PASSWORD
 }

--- a/scripts/openapi/auth/index.ts
+++ b/scripts/openapi/auth/index.ts
@@ -4,6 +4,7 @@ import {
   EmailVerifyRequestBodySchema,
   LoginRequestBodySchema,
   LoginResponseBodySchema,
+  PasswordChangeRequestBodySchema,
   RegisterRequestBodySchema,
   RegisterResponseBodySchema,
 } from '../../../src/domains/auth/schema';
@@ -11,6 +12,24 @@ import { ErrorSchema } from '../../../src/domains/error/schema';
 import { tokenHeader } from '../headers';
 
 export const authApiPaths = {
+  [`${currentApiPrefix}/password`]: {
+    put: {
+      summary: '패스워드 변경 요청 (이메일 인증 선행 필요)',
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: PasswordChangeRequestBodySchema,
+          },
+        },
+      },
+      responses: {
+        200: {
+          description: '패스워드 변경 성공',
+        }
+      }
+    }
+  },
   [`${currentApiPrefix}/verify-email`]: {
     post: {
       summary: '이메일 인증 코드 요청',

--- a/src/domains/auth/controller.ts
+++ b/src/domains/auth/controller.ts
@@ -1,9 +1,9 @@
 import express from 'express';
 import {
-  handleEmailCodeInput,
+  handleRegisterEmailCodeInput,
   handleEmailVerifyRequest,
   handleLogin, handleLogout,
-  handleRegister,
+  handleRegister, handlePasswordReset,
 } from '@/domains/auth/service';
 import {
   authMiddleware,
@@ -17,6 +17,7 @@ authRouter.post('/register', handleRegister);
 authRouter.post('/login', handleLogin);
 authRouter.post('/logout', authMiddleware, handleLogout);
 authRouter.post('/verify-email', verifyEmailRequestLimiter(), handleEmailVerifyRequest);
-authRouter.put('/verify-email', verifyEmailCodeLimiter(), handleEmailCodeInput);
+authRouter.put('/verify-email', verifyEmailCodeLimiter(), handleRegisterEmailCodeInput);
+authRouter.put('/password', handlePasswordReset);
 
 export default authRouter;

--- a/src/domains/auth/schema.ts
+++ b/src/domains/auth/schema.ts
@@ -2,6 +2,17 @@ import { z } from 'zod';
 import { PublicMemberSchema } from '@/domains/member/schema';
 import { MemberSchema } from '@/schemas';
 
+export const PasswordChangeRequestBodySchema = MemberSchema.pick({
+  email: true,
+}).extend({
+  password: z.string()
+  .min(10)
+  .max(25)
+  .regex(
+    /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()_\-+=[{\]};:'",.<>/?\\|`~]).{10,25}$/,
+  ),
+});
+
 export const EmailCodeInputRequestBodySchema = z.object({
   email: z.string().email(),
   code: z.string().max(6),

--- a/src/domains/auth/schema.ts
+++ b/src/domains/auth/schema.ts
@@ -1,10 +1,9 @@
 import { z } from 'zod';
 import { PublicMemberSchema } from '@/domains/member/schema';
-import { MemberSchema } from '@/schemas';
+import { EmailVerificationSchema, MemberSchema } from '@/schemas';
 
-export const PasswordChangeRequestBodySchema = MemberSchema.pick({
-  email: true,
-}).extend({
+export const PasswordChangeRequestBodySchema = z.object({
+  email: z.string().email(),
   password: z.string()
   .min(10)
   .max(25)
@@ -16,10 +15,12 @@ export const PasswordChangeRequestBodySchema = MemberSchema.pick({
 export const EmailCodeInputRequestBodySchema = z.object({
   email: z.string().email(),
   code: z.string().max(6),
+  type: EmailVerificationSchema.shape.type,
 });
 
 export const EmailVerifyRequestBodySchema = z.object({
   email: z.string().email(),
+  type: EmailVerificationSchema.shape.type,
 });
 
 export const RegisterRequestBodySchema = MemberSchema.pick({

--- a/src/domains/auth/service.ts
+++ b/src/domains/auth/service.ts
@@ -7,14 +7,14 @@ import {
   sendVerificationCodeEmail,
 } from '@/domains/auth/utils';
 import {
-  AuthenticatedJWTPayload, AuthenticatedRequest,
+  AuthenticatedJWTPayload,
+  AuthenticatedRequest,
   EmailCodeInputRequest,
   EmailVerifyRequest,
   LoginRequest,
-  LoginResponse,
+  LoginResponse, PasswordChangeRequest,
   RegisterRequest,
   RegisterResponse,
-  ResetPasswordEmailInputRequest,
 } from '@/domains/auth/types';
 import { Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
@@ -22,6 +22,7 @@ import { omitPrivateFields } from '@/domains/member/utils';
 import {
   EmailCodeInputRequestBodySchema,
   EmailVerifyRequestBodySchema,
+  PasswordChangeRequestBodySchema,
   RegisterRequestBodySchema,
 } from '@/domains/auth/schema';
 import jwt from 'jsonwebtoken';
@@ -32,104 +33,50 @@ import {
   NotFoundError,
 } from '@/domains/error/HttpError';
 
-export async function handleResetPasswordEmailInput(req: ResetPasswordEmailInputRequest, res: Response) {
-  const { email } = EmailVerifyRequestBodySchema.parse(req.body);
-  if(! (await isValidEmail(email))) {
-    throw new BadRequestError('잘못된 이메일입니다.');
+export async function handlePasswordReset(req: PasswordChangeRequest, res: Response) {
+  const { password, email } = PasswordChangeRequestBodySchema.parse(req.body);
+  const verifiedEmail = await findVerifiedEmail(email, 'RESET_PASSWORD');
+  if (! verifiedEmail) {
+    throw new BadRequestError('인증이 만료되었거나 유효한 이메일이 아닙니다.');
   }
-  const blacklisted = await prisma.blacklist.findFirst({
-    where: {
-      email
-    }
-  });
-  if(blacklisted) {
-    const date = blacklisted.createdAt;
-    throw new ForbiddenError(`이용약관을 위반하여 재가입이 제한된 이메일입니다(${date.toDateString()}). 관리자에게 문의해주세요`);
-  }
-  const code = await sendVerificationCodeEmail(email);
-  await prisma.emailVerification.updateMany({
+  const hashedPassword = await hashPassword(password);
+  await prisma.member.update({
     where: {
       email,
-      type: 'RESET_PASSWORD',
     },
     data: {
-      expiresAt: new Date(),
-    }
+      password: hashedPassword,
+    },
   });
-  await prisma.emailVerification.create({
-    data: {
-      email,
-      verificationNumber: code,
-      isVerified: false,
-      expiresAt: new Date(Date.now() + 5 * 60 * 1000),
-    }
-  });
-  res.status(StatusCodes.CREATED).send();
-
+  await setVerificationExpired(email, 'RESET_PASSWORD');
+  res.status(StatusCodes.OK).send();
 }
 
-export async function handleEmailCodeInput(req: EmailCodeInputRequest, res: Response) {
-  const { email, code } = EmailCodeInputRequestBodySchema.parse(req.body);
-  const targetEmail = await prisma.emailVerification.findFirst({
-    where: {
-      email,
-      verificationNumber: code,
-      isVerified: false,
-      type: 'REGISTER',
-      expiresAt: {
-        gt: new Date(),
-      }},
-    orderBy: {
-      createdAt: 'desc',
-    }
-  });
+export async function handleRegisterEmailCodeInput(req: EmailCodeInputRequest, res: Response) {
+  const { email, code, type } = EmailCodeInputRequestBodySchema.parse(req.body);
+  const targetEmail = await findEmailVerificationWithCode(email, code, type);
   if(! targetEmail) {
     throw new BadRequestError('인증이 만료되었거나 유효한 이메일이 아닙니다.');
   }
-  await prisma.emailVerification.update({
-    where: {
-      id: targetEmail.id
-    },
-    data: {
-      isVerified: true,
-    }
-  });
+  await setEmailVerifiedByCode(email, code, type);
   res.status(StatusCodes.CREATED).send();
-
 }
 
 export async function handleEmailVerifyRequest(req: EmailVerifyRequest, res: Response) {
-  const { email } = EmailVerifyRequestBodySchema.parse(req.body);
+  const { email, type } = EmailVerifyRequestBodySchema.parse(req.body);
   if(! (await isValidEmail(email))) {
     throw new BadRequestError('등록되지 않은 이메일 도메인입니다.');
   }
-  const blacklisted = await prisma.blacklist.findFirst({
-    where: {
-      email
-    }
-  });
+  const blacklisted = await getBlacklistInfo(email);
   if(blacklisted) {
     const date = blacklisted.createdAt;
     throw new ForbiddenError(`이용약관을 위반하여 재가입이 제한된 이메일입니다(${date.toDateString()}). 관리자에게 문의해주세요`);
   }
   const code = await sendVerificationCodeEmail(email);
-  await prisma.emailVerification.updateMany({
-    where: {
-      email,
-      type: 'REGISTER',
-    },
-    data: {
-      expiresAt: new Date(),
-    }
-  });
-  await prisma.emailVerification.create({
-    data: {
-      email,
-      verificationNumber: code,
-      isVerified: false,
-      expiresAt: new Date(Date.now() + 5 * 60 * 1000),
-    }
-  });
+  await prisma.$transaction([
+    setVerificationExpired(email, type),
+    createEmailVerification(email, code, type)
+  ]);
   res.status(StatusCodes.CREATED).send();
 }
 
@@ -140,28 +87,18 @@ export async function handleRegister(req: RegisterRequest, res: RegisterResponse
       email
     }
   });
+  const verifiedEmail = await findVerifiedEmail(email, 'REGISTER');
+  if (! verifiedEmail) {
+    throw new BadRequestError('인증되지 않은 이메일입니다. 다른 이메일로 시도해주세요.');
+  }
   if(blacklisted) {
     const date = blacklisted.createdAt;
+    await setVerificationExpired(email, 'REGISTER');
     throw new ForbiddenError(`이용약관을 위반하여 재가입이 제한된 이메일입니다(${date.toDateString()}). 관리자에게 문의해주세요`);
-  }
-  const verifiedEmail = await prisma.emailVerification.findFirst({
-    where: {
-      email,
-      isVerified: true,
-      expiresAt: {
-        gt: new Date(),
-      },
-      type: 'REGISTER',
-    },
-    orderBy: {
-      createdAt: 'desc',
-    },
-  });
-  if (! verifiedEmail) {
-    throw new BadRequestError('인증되지 않은 이메일입니다.');
   }
   const existing = await prisma.member.findUnique({ where: { email } });
   if (existing) {
+    await setVerificationExpired(email, 'REGISTER');
     throw new BadRequestError('이미 가입된 이메일입니다.');
   }
 
@@ -186,6 +123,7 @@ export async function handleRegister(req: RegisterRequest, res: RegisterResponse
     },
   });
   const token = generateToken(member);
+  await setVerificationExpired(email, 'REGISTER');
   res.status(StatusCodes.OK).json({ token, member: omitPrivateFields(member)});
 }
 
@@ -213,6 +151,79 @@ export async function handleLogout(req: AuthenticatedRequest, res: Response) {
   const token = req.headers.authorization!.split(' ')[1];
   await saveInvalidatedToken(token);
   res.status(StatusCodes.OK).send();
+}
+
+function setEmailVerifiedByCode(email: string, code: string, type: 'REGISTER' | 'RESET_PASSWORD' = 'REGISTER') {
+  return prisma.emailVerification.updateMany({
+    where: {
+      email,
+      type,
+      verificationNumber: code,
+    },
+    data: {
+      isVerified: true,
+    }
+  });
+}
+
+function setVerificationExpired(email: string, type: 'REGISTER' | 'RESET_PASSWORD' = 'REGISTER') {
+  return prisma.emailVerification.deleteMany({
+    where: {
+      email,
+      type,
+    },
+  });
+}
+
+function findVerifiedEmail(email: string, type: 'REGISTER' | 'RESET_PASSWORD' = 'REGISTER') {
+  return prisma.emailVerification.findFirst({
+    where: {
+      email,
+      type,
+      isVerified: true,
+    },
+    orderBy:{
+      createdAt: 'desc'
+    }
+  });
+}
+
+function findEmailVerificationWithCode(email: string, code: string, type: 'REGISTER' | 'RESET_PASSWORD' = 'REGISTER') {
+  return prisma.emailVerification.findFirst({
+    where: {
+      email,
+      verificationNumber: code,
+      isVerified: false,
+      type,
+      expiresAt: {
+        gt: new Date(),
+      },
+    },
+    orderBy: {
+      createdAt: 'desc',
+    }
+  });
+}
+
+function createEmailVerification(email: string, code: string, type: 'REGISTER' | 'RESET_PASSWORD' = 'REGISTER',
+                                 expiresAt = new Date(Date.now() + 5 * 60 * 1000)) {
+  return prisma.emailVerification.create({
+    data: {
+      email,
+      verificationNumber: code,
+      isVerified: false,
+      expiresAt,
+      type,
+    }
+  });
+}
+
+function getBlacklistInfo(email: string) {
+  return prisma.blacklist.findFirst({
+    where: {
+      email
+    }
+  });
 }
 
 export async function saveInvalidatedToken(accessToken: string) {

--- a/src/domains/auth/types.d.ts
+++ b/src/domains/auth/types.d.ts
@@ -2,7 +2,6 @@ import { Member } from '@/schemas';
 import { Request, Response } from 'express';
 import { z } from 'zod';
 import {
-  EmailCodeInputRequestBodySchema,
   EmailVerifyRequestBodySchema,
   LoginRequestBodySchema,
   LoginResponseBodySchema,
@@ -34,6 +33,4 @@ export type LoginRequest = Request<{}, {}, z.infer<typeof LoginRequestBodySchema
 export type RegisterResponse = Response<z.infer<typeof RegisterResponseBodySchema>>;
 export type LoginResponse = Response<z.infer<typeof LoginResponseBodySchema>>;
 
-export type ResetPasswordEmailInputRequest = Request<{}, {}, z.infer<typeof EmailVerifyRequestBodySchema>>;
-export type ResetPasswordCodeInputRequest = Request<{}, {}, z.infer<typeof EmailCodeInputRequestBodySchema>>;
 export type PasswordChangeRequest = Request<{}, {}, z.infer<typeof PasswordChangeRequestBodySchema>>;

--- a/src/domains/auth/types.d.ts
+++ b/src/domains/auth/types.d.ts
@@ -2,9 +2,11 @@ import { Member } from '@/schemas';
 import { Request, Response } from 'express';
 import { z } from 'zod';
 import {
+  EmailCodeInputRequestBodySchema,
   EmailVerifyRequestBodySchema,
   LoginRequestBodySchema,
   LoginResponseBodySchema,
+  PasswordChangeRequestBodySchema,
   RegisterRequestBodySchema,
   RegisterResponseBodySchema,
 } from '@/domains/auth/schema';
@@ -31,3 +33,7 @@ export type RegisterRequest = Request<{}, {}, z.infer<typeof RegisterRequestBody
 export type LoginRequest = Request<{}, {}, z.infer<typeof LoginRequestBodySchema>>;
 export type RegisterResponse = Response<z.infer<typeof RegisterResponseBodySchema>>;
 export type LoginResponse = Response<z.infer<typeof LoginResponseBodySchema>>;
+
+export type ResetPasswordEmailInputRequest = Request<{}, {}, z.infer<typeof EmailVerifyRequestBodySchema>>;
+export type ResetPasswordCodeInputRequest = Request<{}, {}, z.infer<typeof EmailCodeInputRequestBodySchema>>;
+export type PasswordChangeRequest = Request<{}, {}, z.infer<typeof PasswordChangeRequestBodySchema>>;


### PR DESCRIPTION
# 변경점 👍
비밀번호 재설정을 구현했습니다. 이메일 인증 시 회원가입과 동일한 엔드포인트를 공유하지만, body의 type 인자를 통해 회원가입을 위한 인증인지, 비밀번호 재설정을 위한 인증인지 구별합니다.
