### PR TITLE
모두를 남성으로 만들던 오류 해결 (ISSUE-29)

### DIFF
--- a/src/domains/auth/service.ts
+++ b/src/domains/auth/service.ts
@@ -81,7 +81,7 @@ export async function handleEmailVerifyRequest(req: EmailVerifyRequest, res: Res
 }
 
 export async function handleRegister(req: RegisterRequest, res: RegisterResponse) {
-  const { email, name, password, birth, termsAccepted } = RegisterRequestBodySchema.parse(req.body);
+  const { email, name, password, birth, termsAccepted, gender } = RegisterRequestBodySchema.parse(req.body);
   const blacklisted = await prisma.blacklist.findFirst({
     where: {
       email
@@ -117,6 +117,7 @@ export async function handleRegister(req: RegisterRequest, res: RegisterResponse
       email,
       name,
       birth,
+      gender,
       termsAccepted,
       password: hashedPassword,
       institutionId: institution.id,


### PR DESCRIPTION
# 버그 해결 💊
 성별 디폴트값을 지정해두고 post body에서 값을 입력받지 않아서 모든 회원이 남성이 되던 문제점을 해결했습니다.
