### PR TITLE
채팅방 에러 및 성인이 가입을 못하던 에러 해결 (ISSUE-129)

### DIFF
--- a/src/domains/auth/schema.ts
+++ b/src/domains/auth/schema.ts
@@ -30,7 +30,7 @@ export const RegisterRequestBodySchema = MemberSchema.pick({
 }).extend({
   birth: z.coerce.date()
     .min(new Date('1990-01-01'))
-    .max(new Date(new Date().getFullYear() - 21, 0, 1)),
+    .max(new Date(new Date().getFullYear() - 19, 0, 1)),
   termsAccepted: z.literal(true),
   password: z.string()
   .min(10)

--- a/src/domains/auth/schema.ts
+++ b/src/domains/auth/schema.ts
@@ -28,9 +28,7 @@ export const RegisterRequestBodySchema = MemberSchema.pick({
   password: true,
   name: true,
 }).extend({
-  birth: z.coerce.date()
-    .min(new Date('1990-01-01'))
-    .max(new Date(new Date().getFullYear() - 19, 0, 1)),
+  birth: z.coerce.date(),
   termsAccepted: z.literal(true),
   password: z.string()
   .min(10)

--- a/src/domains/auth/service.ts
+++ b/src/domains/auth/service.ts
@@ -3,6 +3,7 @@ import {
   comparePassword,
   generateToken,
   hashPassword,
+  isBirthInValidRange,
   isValidEmail,
   sendVerificationCodeEmail,
 } from '@/domains/auth/utils';
@@ -88,6 +89,10 @@ export async function handleEmailVerifyRequest(req: EmailVerifyRequest, res: Res
 
 export async function handleRegister(req: RegisterRequest, res: RegisterResponse) {
   const { email, name, password, birth, termsAccepted, gender } = RegisterRequestBodySchema.parse(req.body);
+
+  if(! isBirthInValidRange(birth)) {
+    throw new BadRequestError('만 18세 이상만 가입이 가능한 앱입니다.');
+  }
   const blacklisted = await prisma.blacklist.findFirst({
     where: {
       email

--- a/src/domains/auth/utils.ts
+++ b/src/domains/auth/utils.ts
@@ -42,6 +42,15 @@ export async function sendVerificationCodeEmail(
   return code;
 }
 
+export function isBirthInValidRange(birth: Date) {
+  const now = new Date();
+
+  const minDate = new Date(now.getFullYear() - 19, 0, 1);
+  const maxDate = new Date(1980, 0, 31);
+
+  return birth >= maxDate && birth <= minDate;
+}
+
 
 export function generateToken(member: Member) {
   return jwt.sign({ id: member.id, email: member.email }, JWT_SECRET, { expiresIn: '7d' });

--- a/src/domains/auth/utils.ts
+++ b/src/domains/auth/utils.ts
@@ -45,7 +45,7 @@ export async function sendVerificationCodeEmail(
 export function isBirthInValidRange(birth: Date) {
   const now = new Date();
 
-  const minDate = new Date(now.getFullYear() - 19, 0, 1);
+  const minDate = new Date(now.getFullYear() - 18, 0, 1);
   const maxDate = new Date(1980, 0, 31);
 
   return birth >= maxDate && birth <= minDate;

--- a/src/domains/chat/service.ts
+++ b/src/domains/chat/service.ts
@@ -182,6 +182,7 @@ export async function createChatroom(req: CreateChatroomRequest, res: CreateChat
     where: {
       postId,
       requesterId: member.id,
+      isDeactivated: false,
     }
   });
   const post = await prisma.post.findUnique({


### PR DESCRIPTION
# 변경점 👍
- 만 18세 미만은 가입 시 에러 메시지를 출력하도록 수정했습니다.
 
# 버그 해결 💊
- 성인일 때 가입을 못하던 에러를 수정했습니다.
- 비활성화된 채팅방도 활성화된 채팅방에 포함되던 문제점을 해결했습니다.